### PR TITLE
Keyboard focus in iFrame.

### DIFF
--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/TeaInput.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/TeaInput.java
@@ -21,6 +21,7 @@ import com.github.xpenatan.gdx.backends.teavm.dom.TouchListWrapper;
 import com.github.xpenatan.gdx.backends.teavm.dom.TouchWrapper;
 import com.github.xpenatan.gdx.backends.teavm.dom.WheelEventWrapper;
 import com.github.xpenatan.gdx.backends.teavm.utils.KeyCodes;
+import org.teavm.jso.browser.Window;
 
 /**
  * @author xpenatan
@@ -116,6 +117,9 @@ public class TeaInput implements Input, EventListenerWrapper {
     private void handleMouseEvents(EventWrapper e) {
         String type = e.getType();
         if(type.equals("mousedown")) {
+            // makes sure the game has keyboard focus (e.g. when embedded in iFrame on itch.io)
+            Window.current().focus();
+
             MouseEventWrapper mouseEvent = (MouseEventWrapper)e;
             EventTargetWrapper target = e.getTarget();
             HTMLCanvasElementWrapper canvas2 = canvas;


### PR DESCRIPTION
Keyboard focus is lost/not available when embedded in iFrame (e.g. on itch.io). The code makes sure the focus is requested when someone clicks the game's canvas.