### PR TITLE
Misc. code cleanup: JS, JSNI rename to NATIVE.

### DIFF
--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/TeaClipboard.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/TeaClipboard.java
@@ -1,7 +1,6 @@
 package com.github.xpenatan.gdx.backends.teavm;
 
 import com.badlogic.gdx.utils.Clipboard;
-import com.github.xpenatan.gdx.backends.teavm.dom.HTMLCanvasElementWrapper;
 import org.teavm.jso.JSBody;
 
 /**
@@ -31,7 +30,7 @@ public class TeaClipboard implements Clipboard {
   public void setContents (String content) {
     this.content = content;
     if (requestedWritePermissions || TeaApplication.getAgentInfo().isFirefox()) {
-      if (hasWritePermissions) setContentJSNI(content);
+      if (hasWritePermissions) setContentNATIVE(content);
     } else {
       TeaPermissions.queryPermission("clipboard-write", writeHandler);
       requestedWritePermissions = true;
@@ -42,13 +41,13 @@ public class TeaClipboard implements Clipboard {
           "if (\"clipboard\" in navigator) {\n" +
           "    navigator.clipboard.writeText(content);\n" +
           "}")
-  private static native void setContentJSNI (String content);
+  private static native void setContentNATIVE(String content);
 
   private class ClipboardWriteHandler implements TeaPermissions.TeaPermissionResult {
     @Override
     public void granted () {
       hasWritePermissions = true;
-      setContentJSNI(content);
+      setContentNATIVE(content);
     }
 
     @Override
@@ -59,7 +58,7 @@ public class TeaClipboard implements Clipboard {
     @Override
     public void prompt () {
       hasWritePermissions = true;
-      setContentJSNI(content);
+      setContentNATIVE(content);
     }
   }
 }

--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/TeaGraphics.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/TeaGraphics.java
@@ -19,7 +19,6 @@ import org.teavm.jso.JSBody;
 import org.teavm.jso.JSFunctor;
 import org.teavm.jso.browser.Window;
 import org.teavm.jso.dom.html.HTMLCanvasElement;
-import org.teavm.jso.dom.xml.Document;
 import org.teavm.jso.webgl.WebGLContextAttributes;
 
 /**
@@ -42,7 +41,6 @@ public class TeaGraphics implements Graphics {
 
     public TeaGraphics(TeaApplicationConfiguration config) {
         this.config = config;
-        HTMLCanvasElement a;
         TeaWindow window = new TeaWindow();
         DocumentWrapper document = window.getDocument();
         HTMLElementWrapper elementID = document.getElementById(config.canvasID);
@@ -66,6 +64,14 @@ public class TeaGraphics implements Graphics {
                 setCanvasSize((int)(density * width), (int)(density * height));
             }
         }
+
+        // listen to fullscreen changes
+        addFullscreenChangeListener(canvas, new FullscreenChanged() {
+          @Override
+          public void fullscreenChanged() {
+              // listening to fullscreen mode changes
+          }
+        });
     }
 
     public void update() {
@@ -256,7 +262,7 @@ public class TeaGraphics implements Graphics {
     public boolean setFullscreenMode(DisplayMode displayMode) {
         DisplayMode supportedMode = getDisplayMode();
         if(displayMode.width != supportedMode.width && displayMode.height != supportedMode.height) return false;
-        return setFullscreenJSNI(this, canvas, displayMode.width, displayMode.height);
+        return enterFullscreen(canvas, displayMode.width, displayMode.height);
     }
 
     @Override
@@ -331,11 +337,6 @@ public class TeaGraphics implements Graphics {
     }
 
     @Override
-    public boolean isFullscreen() {
-        return isFullscreenJSNI();
-    }
-
-    @Override
     public Cursor newCursor(Pixmap pixmap, int xHotspot, int yHotspot) {
         return new TeaCursor(pixmap, xHotspot, yHotspot);
     }
@@ -375,112 +376,107 @@ public class TeaGraphics implements Graphics {
     @JSBody(script = "return screen.height;")
     private static native int getScreenHeightNATIVE();
 
-    public boolean setFullscreenJSNI(TeaGraphics graphics, HTMLCanvasElementWrapper canvas, int screenWidth, int screenHeight) {
-        FullscreenChanged fullscreenChanged = new FullscreenChanged() {
-            @Override
-            public void fullscreenChanged() {
-            }
-        };
-        return setFullscreen(fullscreenChanged, canvas, screenWidth, screenHeight);
+    @JSBody(params = {"element", "fullscreenChanged"}, script = "" +
+            "if (element.requestFullscreen) {\n" +
+            "   document.addEventListener(\"fullscreenchange\", fullscreenChanged, false);\n" +
+            "}\n" +
+            "// Attempt to the vendor specific variants of the API\n" +
+            "if (element.webkitRequestFullScreen) {\n" +
+            "   document.addEventListener(\"webkitfullscreenchange\", fullscreenChanged, false);\n" +
+            "}\n" +
+            "if (element.mozRequestFullScreen) {\n" +
+            "   document.addEventListener(\"mozfullscreenchange\", fullscreenChanged, false);\n" +
+            "}\n" +
+            "if (element.msRequestFullscreen) {\n" +
+            "   document.addEventListener(\"msfullscreenchange\", fullscreenChanged, false);\n" +
+            "}")
+    private static native void addFullscreenChangeListener(HTMLCanvasElementWrapper element, FullscreenChanged fullscreenChanged);
+
+    @JSFunctor
+    public interface FullscreenChanged extends org.teavm.jso.JSObject {
+        void fullscreenChanged();
     }
 
-    @JSBody(params = {"fullscreenChanged", "element", "screenWidth", "screenHeight"}, script = "" +
-            "\t\t// Attempt to use the non-prefixed standard API (https://fullscreen.spec.whatwg.org)\n" +
-            "\t\tif (element.requestFullscreen) {\n" +
-            "\t\t\telement.width = screenWidth;\n" +
-            "\t\t\telement.height = screenHeight;\n" +
-            "\t\t\telement.requestFullscreen();\n" +
-            "\t\t\tdocument\n" +
-            "\t\t\t\t\t.addEventListener(\n" +
-            "\t\t\t\t\t\t\t\"fullscreenchange\",\n" +
-            "\t\t\t\t\t\t\tfullscreenChanged, false);\n" +
-            "\t\t\treturn true;\n" +
-            "\t\t}\n" +
-            "\t\t// Attempt to the vendor specific variants of the API\n" +
-            "\t\tif (element.webkitRequestFullScreen) {\n" +
-            "\t\t\telement.width = screenWidth;\n" +
-            "\t\t\telement.height = screenHeight;\n" +
-            "\t\t\telement.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);\n" +
-            "\t\t\tdocument\n" +
-            "\t\t\t\t\t.addEventListener(\n" +
-            "\t\t\t\t\t\t\t\"webkitfullscreenchange\",\n" +
-            "\t\t\t\t\t\t\tfullscreenChanged, false);\n" +
-            "\t\t\treturn true;\n" +
-            "\t\t}\n" +
-            "\t\tif (element.mozRequestFullScreen) {\n" +
-            "\t\t\telement.width = screenWidth;\n" +
-            "\t\t\telement.height = screenHeight;\n" +
-            "\t\t\telement.mozRequestFullScreen();\n" +
-            "\t\t\tdocument\n" +
-            "\t\t\t\t\t.addEventListener(\n" +
-            "\t\t\t\t\t\t\t\"mozfullscreenchange\",\n" +
-            "\t\t\t\t\t\t\tfullscreenChanged, false);\n" +
-            "\t\t\treturn true;\n" +
-            "\t\t}\n" +
-            "\t\tif (element.msRequestFullscreen) {\n" +
-            "\t\t\telement.width = screenWidth;\n" +
-            "\t\t\telement.height = screenHeight;\n" +
-            "\t\t\telement.msRequestFullscreen();\n" +
-            "\t\t\tdocument\n" +
-            "\t\t\t\t\t.addEventListener(\n" +
-            "\t\t\t\t\t\t\t\"msfullscreenchange\",\n" +
-            "\t\t\t\t\t\t\tfullscreenChanged, false);\n" +
-            "\t\t\treturn true;\n" +
-            "\t\t}\n" +
+    public boolean enterFullscreen(HTMLCanvasElementWrapper element, int screenWidth, int screenHeight) {
+        return enterFullscreenNATIVE(element, screenWidth, screenHeight);
+    }
+
+    @JSBody(params = {"element", "screenWidth", "screenHeight"}, script = "" +
+            "if (element.requestFullscreen) {\n" +
+            "   element.width = screenWidth;\n" +
+            "   element.height = screenHeight;\n" +
+            "   element.requestFullscreen();\n" +
+            "   return true;\n" +
+            "}\n" +
+            "// Attempt to the vendor specific variants of the API\n" +
+            "if (element.webkitRequestFullScreen) {\n" +
+            "   element.width = screenWidth;\n" +
+            "   element.height = screenHeight;\n" +
+            "   element.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);\n" +
+            "   return true;\n" +
+            "}\n" +
+            "if (element.mozRequestFullScreen) {\n" +
+            "   element.width = screenWidth;\n" +
+            "   element.height = screenHeight;\n" +
+            "   element.mozRequestFullScreen();\n" +
+            "   return true;\n" +
+            "}\n" +
+            "if (element.msRequestFullscreen) {\n" +
+            "   element.width = screenWidth;\n" +
+            "   element.height = screenHeight;\n" +
+            "   element.msRequestFullscreen();\n" +
+            "   return true;\n" +
+            "}\n" +
             "\n" +
-            "\t\treturn false;")
-    private static native boolean setFullscreen(FullscreenChanged fullscreenChanged, HTMLCanvasElementWrapper element, int screenWidth, int screenHeight);
+            "return false;")
+    private static native boolean enterFullscreenNATIVE(HTMLCanvasElementWrapper element, int screenWidth, int screenHeight);
 
     public void exitFullscreen() {
-        exitFullscreenJS();
+        exitFullscreenNATIVE();
     }
 
     @JSBody(script = "" +
             "if (document.exitFullscreen)\n" +
-            "document.exitFullscreen();\n" +
+            "  document.exitFullscreen();\n" +
             "if (document.msExitFullscreen)\n" +
-            "document.msExitFullscreen();\n" +
+            "  document.msExitFullscreen();\n" +
             "if (document.webkitExitFullscreen)\n" +
-            "document.webkitExitFullscreen();\n" +
+            "  document.webkitExitFullscreen();\n" +
             "if (document.mozExitFullscreen)\n" +
-            "document.mozExitFullscreen();\n" +
+            "  document.mozExitFullscreen();\n" +
             "if (document.webkitCancelFullScreen) // Old WebKit\n" +
-            "document.webkitCancelFullScreen();")
-    private static native boolean exitFullscreenJS();
+            "  document.webkitCancelFullScreen();")
+    private static native boolean exitFullscreenNATIVE();
 
-    public boolean isFullscreenJSNI() {
+    @Override
+    public boolean isFullscreen() {
         return isFullscreenNATIVE();
     }
 
     @JSBody(script = "" +
             "// Standards compliant check for fullscreen\n" +
             "if (\"fullscreenElement\" in document) {\n" +
-            "return document.fullscreenElement != null;\n" +
+            "  return document.fullscreenElement != null;\n" +
             "}" +
             "// Vendor prefixed versions of standard check\n" +
             "if (\"msFullscreenElement\" in document) {\n" +
-            "return document.msFullscreenElement != null;\n" +
+            "  return document.msFullscreenElement != null;\n" +
             "}" +
             "if (\"webkitFullscreenElement\" in document) {\n" +
-            "return document.webkitFullscreenElement != null;\n" +
+            "  return document.webkitFullscreenElement != null;\n" +
             "}" +
             "if (\"mozFullScreenElement\" in document) { // Yes, with a capital 'S'\n" +
-            "return document.mozFullScreenElement != null;\n" +
+            "  return document.mozFullScreenElement != null;\n" +
             "}" +
             "// Older, non-standard ways of checking for fullscreen\n" +
             "if (\"webkitIsFullScreen\" in document) {\n" +
-            "return document.webkitIsFullScreen;\n" +
+            "  return document.webkitIsFullScreen;\n" +
             "}" +
             "if (\"mozFullScreen\" in document) {\n" +
-            "return document.mozFullScreen;\n" +
+            "  return document.mozFullScreen;\n" +
             "}" +
             "return false")
     private static native boolean isFullscreenNATIVE();
-
-    @JSFunctor
-    public interface FullscreenChanged extends org.teavm.jso.JSObject {
-        void fullscreenChanged();
-    }
 
     public WebGLRenderingContextWrapper getGLContext(HTMLCanvasElementWrapper canvasWrapper, TeaApplicationConfiguration config) {
         WebGLContextAttributes attr = WebGLContextAttributes.create();

--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/TeaPreferences.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/TeaPreferences.java
@@ -41,10 +41,10 @@ public class TeaPreferences implements Preferences {
     }
 
     private Object toObject(String key, String value) {
-        if(key.endsWith("b")) return new Boolean(Boolean.parseBoolean(value));
-        if(key.endsWith("i")) return new Integer(Integer.parseInt(value));
-        if(key.endsWith("l")) return new Long(Long.parseLong(value));
-        if(key.endsWith("f")) return new Float(Float.parseFloat(value));
+        if(key.endsWith("b")) return Boolean.valueOf(value);
+        if(key.endsWith("i")) return Integer.valueOf(value);
+        if(key.endsWith("l")) return Long.valueOf(value);
+        if(key.endsWith("f")) return Float.valueOf(value);
         return value;
     }
 


### PR DESCRIPTION
I did some code improvements.

- consistency: calling native functions now with the name `...NATIVE(...)` instead of `JS(...)` or `JSNI(...)`
- improved fullscreen mode: e.g. the listener doesn't need to be added every time we switch to fullscreen mode. Once when `TeaGraphics` is created is enough.
- `new Boolean(...)`/etc. replaced with `Boolean.valueOf(...)`.