### PR TITLE
Bugfix: Asset Loading & Error "ERR_HTTP2_SERVER_REFUSED_STREAM"

### DIFF
--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/preloader/AssetDownloadImpl.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/preloader/AssetDownloadImpl.java
@@ -86,74 +86,86 @@ public class AssetDownloadImpl implements AssetDownload {
     public void loadText(boolean async, String url, AssetLoaderListener<String> listener) {
         if(showLog)
             System.out.println("Loading asset : " + url);
-        final XMLHttpRequestWrapper request = (XMLHttpRequestWrapper)XMLHttpRequest.create();
-        request.setOnreadystatechange(new EventHandlerWrapper() {
-            @Override
-            public void handleEvent(EventWrapper evt) {
-                if(request.getReadyState() == XMLHttpRequestWrapper.DONE) {
-                    if(request.getStatus() != 200) {
-                        if (request.getStatus() != 404) {
-                            // re-try: e.g. failure due to ERR_HTTP2_SERVER_REFUSED_STREAM (too many requests)
-                            loadText(async, url, listener);
-                        }
-                        else {
-                            listener.onFailure(url);
-                        }
-                    }
-                    else {
-                        if(showLog)
-                            System.out.println("Asset loaded: " + url);
-                        listener.onSuccess(url, request.getResponseText());
-                    }
-                    subtractQueue();
-                }
-            }
-        });
+
+        // don't load on main thread
         addQueue();
-        setOnProgress(request, listener);
-        request.open("GET", url, async);
-        request.setRequestHeader("Content-Type", "text/plain; charset=utf-8");
-        request.send();
+        new Thread() {
+            public void run() {
+                final XMLHttpRequestWrapper request = (XMLHttpRequestWrapper)XMLHttpRequest.create();
+                request.setOnreadystatechange(new EventHandlerWrapper() {
+                    @Override
+                    public void handleEvent(EventWrapper evt) {
+                        if(request.getReadyState() == XMLHttpRequestWrapper.DONE) {
+                            if(request.getStatus() != 200) {
+                                if (request.getStatus() != 404) {
+                                    // re-try: e.g. failure due to ERR_HTTP2_SERVER_REFUSED_STREAM (too many requests)
+                                    loadText(async, url, listener);
+                                }
+                                else {
+                                    listener.onFailure(url);
+                                }
+                            }
+                            else {
+                                if(showLog)
+                                    System.out.println("Asset loaded: " + url);
+                                listener.onSuccess(url, request.getResponseText());
+                            }
+                            subtractQueue();
+                        }
+                    }
+                });
+                setOnProgress(request, listener);
+                request.open("GET", url, async);
+                request.setRequestHeader("Content-Type", "text/plain; charset=utf-8");
+                request.send();
+            }
+        }.start();
     }
 
     @Override
     public void loadScript(boolean async, String url, AssetLoaderListener<Object> listener) {
         if(showLog)
             System.out.println("Loading script : " + url);
-        final XMLHttpRequestWrapper request = (XMLHttpRequestWrapper)XMLHttpRequest.create();
-        request.setOnreadystatechange(new EventHandlerWrapper() {
-            @Override
-            public void handleEvent(EventWrapper evt) {
-                if(request.getReadyState() == XMLHttpRequestWrapper.DONE) {
-                    if(request.getStatus() != 200) {
-                        if (request.getStatus() != 404) {
-                            // re-try: e.g. failure due to ERR_HTTP2_SERVER_REFUSED_STREAM (too many requests)
-                            loadScript(async, url, listener);
-                        }
-                        else {
-                            listener.onFailure(url);
-                        }
-                    }
-                    else {
-                        if(showLog)
-                            System.out.println("Script loaded: " + url);
-                        NodeWrapper response = request.getResponse();
-                        TeaWindow currentWindow = TeaWindow.get();
-                        DocumentWrapper document = currentWindow.getDocument();
-                        HTMLElementWrapper scriptElement = document.createElement("script");
-                        scriptElement.appendChild(document.createTextNode(response));
-                        document.getBody().appendChild(scriptElement);
-                        listener.onSuccess(url, request.getResponseText());
-                    }
-                    subtractQueue();
-                }
-            }
-        });
+
+        // don't load on main thread
         addQueue();
-        setOnProgress(request, listener);
-        request.open("GET", url, async);
-        request.setRequestHeader("Content-Type", "text/plain; charset=utf-8");
-        request.send();
+        new Thread() {
+            public void run() {
+                final XMLHttpRequestWrapper request = (XMLHttpRequestWrapper)XMLHttpRequest.create();
+                request.setOnreadystatechange(new EventHandlerWrapper() {
+                    @Override
+                    public void handleEvent(EventWrapper evt) {
+                        if(request.getReadyState() == XMLHttpRequestWrapper.DONE) {
+                            if(request.getStatus() != 200) {
+                                if (request.getStatus() != 404) {
+                                    // re-try: e.g. failure due to ERR_HTTP2_SERVER_REFUSED_STREAM (too many requests)
+                                    loadScript(async, url, listener);
+                                }
+                                else {
+                                    listener.onFailure(url);
+                                }
+                            }
+                            else {
+                                if(showLog)
+                                    System.out.println("Script loaded: " + url);
+                                NodeWrapper response = request.getResponse();
+                                TeaWindow currentWindow = TeaWindow.get();
+                                DocumentWrapper document = currentWindow.getDocument();
+                                HTMLElementWrapper scriptElement = document.createElement("script");
+                                scriptElement.appendChild(document.createTextNode(response));
+                                document.getBody().appendChild(scriptElement);
+                                listener.onSuccess(url, request.getResponseText());
+                            }
+                            subtractQueue();
+                        }
+                    }
+                });
+                setOnProgress(request, listener);
+                request.open("GET", url, async);
+                request.setRequestHeader("Content-Type", "text/plain; charset=utf-8");
+                request.send();
+            }
+        }.start();
     }
 
     public void loadAudio(boolean async, final String url, final AssetLoaderListener<Void> listener) {
@@ -178,40 +190,46 @@ public class AssetDownloadImpl implements AssetDownload {
     public void loadBinary(boolean async, final String url, final AssetLoaderListener<Blob> listener) {
         if(showLog)
             System.out.println("Loading asset : " + url);
-        XMLHttpRequestWrapper request = (XMLHttpRequestWrapper)XMLHttpRequest.create();
-        request.setOnreadystatechange(new EventHandlerWrapper() {
-            @Override
-            public void handleEvent(EventWrapper evt) {
-                if(request.getReadyState() == XMLHttpRequestWrapper.DONE) {
-                    if(request.getStatus() != 200) {
-                        if (request.getStatus() != 404) {
-                            // re-try: e.g. failure due to ERR_HTTP2_SERVER_REFUSED_STREAM (too many requests)
-                            loadBinary(async, url, listener);
-                        }
-                        else {
-                            listener.onFailure(url);
-                        }
-                    }
-                    else {
-                        if(showLog)
-                            System.out.println("Asset loaded: " + url);
 
-                        ArrayBufferWrapper response = (ArrayBufferWrapper)request.getResponse();
-                        Int8ArrayWrapper data = TypedArrays.getInstance().createInt8Array(response);
-                        listener.onSuccess(url, new Blob(response, data));
-                    }
-                    subtractQueue();
-                }
-            }
-        });
-
+        // don't load on main thread
         addQueue();
-        setOnProgress(request, listener);
-        request.open("GET", url, async);
-        if(async) {
-            request.setResponseType("arraybuffer");
-        }
-        request.send();
+        new Thread() {
+            public void run() {
+                XMLHttpRequestWrapper request = (XMLHttpRequestWrapper)XMLHttpRequest.create();
+                request.setOnreadystatechange(new EventHandlerWrapper() {
+                    @Override
+                    public void handleEvent(EventWrapper evt) {
+                        if(request.getReadyState() == XMLHttpRequestWrapper.DONE) {
+                            if(request.getStatus() != 200) {
+                                if (request.getStatus() != 404) {
+                                    // re-try: e.g. failure due to ERR_HTTP2_SERVER_REFUSED_STREAM (too many requests)
+                                    loadBinary(async, url, listener);
+                                }
+                                else {
+                                    listener.onFailure(url);
+                                }
+                            }
+                            else {
+                                if(showLog)
+                                    System.out.println("Asset loaded: " + url);
+
+                                ArrayBufferWrapper response = (ArrayBufferWrapper)request.getResponse();
+                                Int8ArrayWrapper data = TypedArrays.getInstance().createInt8Array(response);
+                                listener.onSuccess(url, new Blob(response, data));
+                            }
+                            subtractQueue();
+                        }
+                    }
+                });
+
+                setOnProgress(request, listener);
+                request.open("GET", url, async);
+                if(async) {
+                    request.setResponseType("arraybuffer");
+                }
+                request.send();
+            }
+        }.start();
     }
 
     public void loadImage(boolean async, final String url, final String mimeType,

--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/preloader/AssetDownloadImpl.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/preloader/AssetDownloadImpl.java
@@ -99,6 +99,12 @@ public class AssetDownloadImpl implements AssetDownload {
                             if(request.getStatus() != 200) {
                                 if (request.getStatus() != 404) {
                                     // re-try: e.g. failure due to ERR_HTTP2_SERVER_REFUSED_STREAM (too many requests)
+                                    try {
+                                        Thread.sleep(100);
+                                    }
+                                    catch (Throwable e) {
+                                        // ignored
+                                    }
                                     loadText(async, url, listener);
                                 }
                                 else {
@@ -139,6 +145,12 @@ public class AssetDownloadImpl implements AssetDownload {
                             if(request.getStatus() != 200) {
                                 if (request.getStatus() != 404) {
                                     // re-try: e.g. failure due to ERR_HTTP2_SERVER_REFUSED_STREAM (too many requests)
+                                    try {
+                                        Thread.sleep(100);
+                                    }
+                                    catch (Throwable e) {
+                                        // ignored
+                                    }
                                     loadScript(async, url, listener);
                                 }
                                 else {
@@ -203,6 +215,12 @@ public class AssetDownloadImpl implements AssetDownload {
                             if(request.getStatus() != 200) {
                                 if (request.getStatus() != 404) {
                                     // re-try: e.g. failure due to ERR_HTTP2_SERVER_REFUSED_STREAM (too many requests)
+                                    try {
+                                        Thread.sleep(100);
+                                    }
+                                    catch (Throwable e) {
+                                        // ignored
+                                    }
                                     loadBinary(async, url, listener);
                                 }
                                 else {

--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/preloader/AssetDownloadImpl.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/preloader/AssetDownloadImpl.java
@@ -1,7 +1,5 @@
 package com.github.xpenatan.gdx.backends.teavm.preloader;
 
-import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.github.xpenatan.gdx.backends.teavm.AssetLoaderListener;
 import com.github.xpenatan.gdx.backends.teavm.dom.DocumentWrapper;

--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/preloader/AssetDownloadImpl.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/preloader/AssetDownloadImpl.java
@@ -1,6 +1,7 @@
 package com.github.xpenatan.gdx.backends.teavm.preloader;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.github.xpenatan.gdx.backends.teavm.AssetLoaderListener;
 import com.github.xpenatan.gdx.backends.teavm.dom.DocumentWrapper;
@@ -22,9 +23,6 @@ import org.teavm.jso.ajax.XMLHttpRequest;
 import org.teavm.jso.browser.Window;
 
 public class AssetDownloadImpl implements AssetDownload {
-
-    /** Max. tries, in case we are too fast. Should limit error "ERR_HTTP2_SERVER_REFUSED_STREAM". */
-    private static final int MAX_TRIES = 3;
 
     private int queue;
     private boolean useBrowserCache = false;
@@ -88,10 +86,6 @@ public class AssetDownloadImpl implements AssetDownload {
 
     @Override
     public void loadText(boolean async, String url, AssetLoaderListener<String> listener) {
-      loadText(async, url, listener, 0);
-    }
-
-    private void loadText(boolean async, String url, AssetLoaderListener<String> listener, int tries) {
         if(showLog)
             System.out.println("Loading asset : " + url);
         final XMLHttpRequestWrapper request = (XMLHttpRequestWrapper)XMLHttpRequest.create();
@@ -100,13 +94,12 @@ public class AssetDownloadImpl implements AssetDownload {
             public void handleEvent(EventWrapper evt) {
                 if(request.getReadyState() == XMLHttpRequestWrapper.DONE) {
                     if(request.getStatus() != 200) {
-                        System.err.println("Error loading \"" + url + "\" (tries: " + tries + ").");
-                        if (tries <= MAX_TRIES) {
-                          // we re-try: maybe too many requests, e.g. error "ERR_HTTP2_SERVER_REFUSED_STREAM"
-                          loadText(async, url, listener, tries + 1);
+                        if (request.getStatus() != 404) {
+                            // re-try: e.g. failure due to ERR_HTTP2_SERVER_REFUSED_STREAM (too many requests)
+                            loadText(async, url, listener);
                         }
                         else {
-                          listener.onFailure(url);
+                            listener.onFailure(url);
                         }
                     }
                     else {
@@ -127,10 +120,6 @@ public class AssetDownloadImpl implements AssetDownload {
 
     @Override
     public void loadScript(boolean async, String url, AssetLoaderListener<Object> listener) {
-      loadScript(async, url, listener, 0);
-    }
-
-    private void loadScript(boolean async, String url, AssetLoaderListener<Object> listener, int tries) {
         if(showLog)
             System.out.println("Loading script : " + url);
         final XMLHttpRequestWrapper request = (XMLHttpRequestWrapper)XMLHttpRequest.create();
@@ -139,13 +128,12 @@ public class AssetDownloadImpl implements AssetDownload {
             public void handleEvent(EventWrapper evt) {
                 if(request.getReadyState() == XMLHttpRequestWrapper.DONE) {
                     if(request.getStatus() != 200) {
-                        System.err.println("Error loading \"" + url + "\" (tries: " + tries + ").");
-                        if (tries <= MAX_TRIES) {
-                          // we re-try: maybe too many requests, e.g. error "ERR_HTTP2_SERVER_REFUSED_STREAM"
-                          loadScript(async, url, listener, tries + 1);
+                        if (request.getStatus() != 404) {
+                            // re-try: e.g. failure due to ERR_HTTP2_SERVER_REFUSED_STREAM (too many requests)
+                            loadScript(async, url, listener);
                         }
                         else {
-                          listener.onFailure(url);
+                            listener.onFailure(url);
                         }
                     }
                     else {
@@ -190,10 +178,6 @@ public class AssetDownloadImpl implements AssetDownload {
     }
 
     public void loadBinary(boolean async, final String url, final AssetLoaderListener<Blob> listener) {
-      loadBinary(async, url, listener, 0);
-    }
-
-    private void loadBinary(boolean async, final String url, final AssetLoaderListener<Blob> listener, int tries) {
         if(showLog)
             System.out.println("Loading asset : " + url);
         XMLHttpRequestWrapper request = (XMLHttpRequestWrapper)XMLHttpRequest.create();
@@ -202,13 +186,12 @@ public class AssetDownloadImpl implements AssetDownload {
             public void handleEvent(EventWrapper evt) {
                 if(request.getReadyState() == XMLHttpRequestWrapper.DONE) {
                     if(request.getStatus() != 200) {
-                        System.err.println("Error loading \"" + url + "\" (tries: " + tries + ").");
-                        if (tries <= MAX_TRIES) {
-                          // we re-try: maybe too many requests, e.g. error "ERR_HTTP2_SERVER_REFUSED_STREAM"
-                          loadBinary(async, url, listener, tries + 1);
+                        if (request.getStatus() != 404) {
+                            // re-try: e.g. failure due to ERR_HTTP2_SERVER_REFUSED_STREAM (too many requests)
+                            loadBinary(async, url, listener);
                         }
                         else {
-                          listener.onFailure(url);
+                            listener.onFailure(url);
                         }
                     }
                     else {


### PR DESCRIPTION
I encountered an error if too many assets are loaded. On HTTP/2, loading more than a certain amount of assets at the same, the server might respond with an `ERR_HTTP2_SERVER_REFUSED_STREAM` error (e.g. IONOS provider). 

I have mitigated the problem:
 - unless it's a `404`, an asset is re-tried to be loaded
 - asset loading now in a `Thread`.

This seems to fix the problem. If an error is encountered, the downloader simply tries to re-download after a short pause of `100ms`.