### PR TITLE
Bugfix: blank line on top of HTML body on mobile.

### DIFF
--- a/backends/backend-teavm/src/main/resources/webapp/index.html
+++ b/backends/backend-teavm/src/main/resources/webapp/index.html
@@ -8,8 +8,10 @@
         justify-content: center;
         align-items: center;
         background: #000;
-        display: flex;
         height: 100vh;
+        margin: 0;
+        padding: 0;
+        overflow: hidden
       }
       #progress {
         position: fixed;
@@ -49,7 +51,7 @@
       }
     </style>
 </head>
-<body style="margin:0;padding:0;overflow: hidden" oncontextmenu="return false" onload="main(%ARGS%)">
+<body oncontextmenu="return false" onload="main(%ARGS%)">
 <div>
   <div id="progress">
     %LOGO%


### PR DESCRIPTION
The CSS parameter `display: flex` produced a blank line on top of the HTML document on mobile devices. I also moved the style paremeters for `<BODY>` into the style section.

Fixes: https://github.com/xpenatan/gdx-teavm/issues/87