### PR TITLE
Storage Prefix to TeaApplicationConfiguration

### DIFF
--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/TeaApplication.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/TeaApplication.java
@@ -305,6 +305,10 @@ public class TeaApplication implements Application, Runnable {
         return preloader;
     }
 
+    public TeaApplicationConfiguration getConfig() {
+        return config;
+    }
+
     @Override
     public ApplicationListener getApplicationListener() {
         return appListener;
@@ -410,7 +414,7 @@ public class TeaApplication implements Application, Runnable {
         Preferences pref = prefs.get(name);
         if(pref == null) {
             Storage storage = Storage.getLocalStorage();;
-            pref = new TeaPreferences(storage, name);
+            pref = new TeaPreferences(storage, config.storagePrefix + name);
             prefs.put(name, pref);
         }
         return pref;

--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/TeaApplicationConfiguration.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/TeaApplicationConfiguration.java
@@ -13,6 +13,17 @@ public class TeaApplicationConfiguration {
     public boolean preloadAssets = true;
 
     /**
+     * The prefix for the browser storage. If you have multiple apps on the same server and want to keep the
+     * data separate for those applications, you will need to set unique prefixes. This is useful if you are
+     * e.g. uploading multiple webapps to itch.io and want to keep the data separate for each application.
+     * <p>
+     * For example use "app1_" for one, and "app2_" for the other application, so the data that is stored in the
+     * browser is not shared between the applications. If you leave the storage prefix at "", all the data
+     * and files stored will be shared between the applications.
+     */
+    public String storagePrefix = "";
+
+    /**
      * Show download logs.
      */
     public boolean showDownloadLogs = false;

--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/filesystem/FileDB.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/filesystem/FileDB.java
@@ -1,8 +1,10 @@
 package com.github.xpenatan.gdx.backends.teavm.filesystem;
 
 import com.badlogic.gdx.Files;
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.github.xpenatan.gdx.backends.teavm.TeaApplication;
 import com.github.xpenatan.gdx.backends.teavm.TeaFileHandle;
 import java.io.ByteArrayOutputStream;
 import java.io.FileFilter;
@@ -82,7 +84,7 @@ public abstract class FileDB {
             if((path.length() > 0) && (path.charAt(path.length() - 1) == '/')) {
                 path = path.substring(0, path.length() - 1);
             }
-            files[i] = new TeaFileHandle(null, path, Files.FileType.Local);
+            files[i] = new TeaFileHandle(((TeaApplication)Gdx.app).getPreloader(), path, Files.FileType.Local);
         }
         return files;
     }

--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/filesystem/FileDBManager.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/filesystem/FileDBManager.java
@@ -1,5 +1,7 @@
 package com.github.xpenatan.gdx.backends.teavm.filesystem;
 
+import com.badlogic.gdx.Gdx;
+import com.github.xpenatan.gdx.backends.teavm.TeaApplication;
 import com.github.xpenatan.gdx.backends.teavm.TeaFileHandle;
 
 import java.io.InputStream;
@@ -21,7 +23,7 @@ public final class FileDBManager extends FileDB {
     private final FileDBStorage memory;
 
     FileDBManager() {
-        localStorage = new FileDBStorage(new StoreLocal());
+        localStorage = new FileDBStorage(new StoreLocal(((TeaApplication)Gdx.app).getConfig().storagePrefix));
         memory = new FileDBStorage(new StoreMemory());
     }
 

--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/filesystem/FileDBStorage.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/filesystem/FileDBStorage.java
@@ -30,10 +30,6 @@ final class FileDBStorage extends FileDB {
         this.store = store;
     }
 
-    Store storage() {
-        return store;
-    }
-
     @Override
     public InputStream read(TeaFileHandle file) {
         // we obtain the stored byte array
@@ -70,7 +66,7 @@ final class FileDBStorage extends FileDB {
         for(int i = 0; i < length; i++) {
             // cut the identifier for files and directories and add to path list
             String key = store.key(i);
-            if (key.startsWith(ID_FOR_DIR) || key.startsWith(ID_FOR_FILE)) {
+            if ((key != null) && ((key.startsWith(ID_FOR_DIR) || key.startsWith(ID_FOR_FILE)))) {
                 String path = key.substring(ID_LENGTH);
                 if(path.startsWith(dir)) {
                     paths.add(path);

--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/filesystem/Store.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/filesystem/Store.java
@@ -1,12 +1,15 @@
 package com.github.xpenatan.gdx.backends.teavm.filesystem;
 
 /**
+ * Definition for a key-based file store.
+ * 
  * @author noblemaster
  */
 public interface Store {
 
-  int getLength() ;
+  int getLength();
 
+  /** The key or 'null' if it's not related to this application. */
   String key(int i);
 
   String getItem(String key);

--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/filesystem/StoreLocal.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/filesystem/StoreLocal.java
@@ -14,8 +14,14 @@ class StoreLocal implements Store {
      */
     private final Storage storage;
 
-    StoreLocal() {
+    /**
+     * Prefix that makes sure multiple applications on the same server don't use the same paths.
+     */
+    private final String prefix;
+
+    StoreLocal(String prefix) {
         storage = Storage.getLocalStorage();
+        this.prefix = prefix;
     }
 
     @Override
@@ -25,22 +31,28 @@ class StoreLocal implements Store {
 
     @Override
     public String key(int i) {
-        return storage.key(i);
+        String key = storage.key(i);
+        if (key.startsWith(prefix)) {
+            return key.substring(prefix.length());
+        }
+        else {
+            return null;
+        }
     }
 
     @Override
     public String getItem(String key) {
-        return storage.getItem(key);
+        return storage.getItem(prefix + key);
     }
 
     @Override
     public void setItem(String key, String item) {
-        storage.setItem(key, item);
+        storage.setItem(prefix + key, item);
     }
 
     @Override
     public void removeItem(String key) {
-        storage.removeItem(key);
+        storage.removeItem(prefix + key);
     }
 
     @Override


### PR DESCRIPTION
I found a problem when having multiple webapps on the same server (e.g. on itch.io). The data for `TeaPreferences` and `TeaFileHandle` is all shared if the domain URL is the same. 

If you have multiple apps on the same server and want to keep the data separate for those applications, you will need to set unique prefixes via `storagePrefix`. This is useful if you are e.g. uploading multiple webapps to itch.io and want to keep the data separate for each application.