### PR TITLE
Improve arraybuffer copy performance

### DIFF
--- a/backends/backend-teavm/emu/org/teavm/classlib/java/nio/FloatBufferOverArrayEmu.java
+++ b/backends/backend-teavm/emu/org/teavm/classlib/java/nio/FloatBufferOverArrayEmu.java
@@ -1,35 +1,34 @@
 package org.teavm.classlib.java.nio;
 
 import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.ArrayBufferViewWrapper;
-import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.Int8ArrayWrapper;
+import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.Float32ArrayWrapper;
 import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.TypedArrays;
 import com.github.xpenatan.gdx.backends.teavm.gen.Emulate;
-import org.teavm.jso.JSObject;
 
-@Emulate(valueStr = "java.nio.ByteBufferImpl", updateCode = true)
-public abstract class ByteBufferImplEmu extends TByteBufferImpl implements HasArrayBufferView {
+@Emulate(valueStr = "java.nio.TFloatBufferOverArray", updateCode = true)
+public abstract class FloatBufferOverArrayEmu extends TFloatBufferOverArray implements HasArrayBufferView {
 
     @Emulate
-    Int8ArrayWrapper backupArray;
+    Float32ArrayWrapper backupArray;
     @Emulate
     int positionCache;
     @Emulate
     int remainingCache;
 
-    public ByteBufferImplEmu(int start, int capacity, byte[] array, int position, int limit, boolean direct, boolean readOnly) {
-        super(start, capacity, array, position, limit, direct, readOnly);
+    public FloatBufferOverArrayEmu(int start, int capacity, float[] array, int position, int limit, boolean readOnly) {
+        super(start, capacity, array, position, limit, readOnly);
     }
 
     @Override
     @Emulate
     public ArrayBufferViewWrapper getArrayBufferView() {
-        Int8ArrayWrapper int8Array = (Int8ArrayWrapper)getOriginalArrayBufferView();
+        Float32ArrayWrapper originalBuffer = (Float32ArrayWrapper)getOriginalArrayBufferView();
         int position1 = position();
         int remaining1 = remaining();
         if(backupArray == null || positionCache != position1 || remaining1 != remainingCache) {
             positionCache = position1;
             remainingCache = remaining1;
-            backupArray = int8Array.subarray(position1, remaining1);
+            backupArray = originalBuffer.subarray(position1, remaining1);
         }
         return backupArray;
     }
@@ -37,14 +36,12 @@ public abstract class ByteBufferImplEmu extends TByteBufferImpl implements HasAr
     @Override
     @Emulate
     public ArrayBufferViewWrapper getOriginalArrayBufferView() {
-        Object array = array();
-        Int8ArrayWrapper int8Array = TypedArrays.getArrayBufferView((JSObject)array);
-        return int8Array;
+        return TypedArrays.getTypedArray(array);
     }
 
     @Override
     @Emulate
     public int getElementSize() {
-        return 1;
+        return 4;
     }
 }

--- a/backends/backend-teavm/emu/org/teavm/classlib/java/nio/FloatBufferOverByteBufferEmu.java
+++ b/backends/backend-teavm/emu/org/teavm/classlib/java/nio/FloatBufferOverByteBufferEmu.java
@@ -1,11 +1,22 @@
 package org.teavm.classlib.java.nio;
 
 import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.ArrayBufferViewWrapper;
+import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.Float32ArrayWrapper;
 import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.Int8ArrayWrapper;
+import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.TypedArrays;
 import com.github.xpenatan.gdx.backends.teavm.gen.Emulate;
 
 @Emulate(valueStr = "java.nio.FloatBufferOverByteBuffer", updateCode = true)
 public abstract class FloatBufferOverByteBufferEmu extends TFloatBufferOverByteBuffer implements HasArrayBufferView {
+
+    @Emulate
+    Float32ArrayWrapper backupArray;
+    @Emulate
+    Float32ArrayWrapper floatArray;
+    @Emulate
+    int positionCache;
+    @Emulate
+    int remainingCache;
 
     public FloatBufferOverByteBufferEmu(int start, int capacity, TByteBufferImpl byteBuffer, int position, int limit, boolean readOnly) {
         super(start, capacity, byteBuffer, position, limit, readOnly);
@@ -13,9 +24,28 @@ public abstract class FloatBufferOverByteBufferEmu extends TFloatBufferOverByteB
 
     @Override
     @Emulate
-    public Int8ArrayWrapper getTypedArray() {
+    public ArrayBufferViewWrapper getArrayBufferView() {
+        // Int8Array
+        Int8ArrayWrapper int8Array = (Int8ArrayWrapper)getOriginalArrayBufferView();
+        if(floatArray == null) {
+            floatArray = TypedArrays.createFloat32Array(int8Array.getBuffer());
+        }
+
+        int position1 = position();
+        int remaining1 = remaining();
+        if(backupArray == null || positionCache != position1 || remaining1 != remainingCache) {
+            positionCache = position1;
+            remainingCache = remaining1;
+            backupArray = floatArray.subarray(position1, remaining1);
+        }
+        return backupArray;
+    }
+
+    @Override
+    @Emulate
+    public ArrayBufferViewWrapper getOriginalArrayBufferView() {
         HasArrayBufferView buff = (HasArrayBufferView)byteByffer;
-        return buff.getTypedArray();
+        return buff.getOriginalArrayBufferView();
     }
 
     @Override

--- a/backends/backend-teavm/emu/org/teavm/classlib/java/nio/HasArrayBufferView.java
+++ b/backends/backend-teavm/emu/org/teavm/classlib/java/nio/HasArrayBufferView.java
@@ -1,8 +1,9 @@
 package org.teavm.classlib.java.nio;
 
-import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.Int8ArrayWrapper;
+import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.ArrayBufferViewWrapper;
 
 public interface HasArrayBufferView {
-    Int8ArrayWrapper getTypedArray();
+    ArrayBufferViewWrapper getArrayBufferView();
+    ArrayBufferViewWrapper getOriginalArrayBufferView();
     int getElementSize();
 }

--- a/backends/backend-teavm/emu/org/teavm/classlib/java/nio/IntBufferOverArrayEmu.java
+++ b/backends/backend-teavm/emu/org/teavm/classlib/java/nio/IntBufferOverArrayEmu.java
@@ -1,35 +1,34 @@
 package org.teavm.classlib.java.nio;
 
 import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.ArrayBufferViewWrapper;
-import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.Int8ArrayWrapper;
+import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.Int32ArrayWrapper;
 import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.TypedArrays;
 import com.github.xpenatan.gdx.backends.teavm.gen.Emulate;
-import org.teavm.jso.JSObject;
 
-@Emulate(valueStr = "java.nio.ByteBufferImpl", updateCode = true)
-public abstract class ByteBufferImplEmu extends TByteBufferImpl implements HasArrayBufferView {
+@Emulate(valueStr = "java.nio.TIntBufferOverArray", updateCode = true)
+public abstract class IntBufferOverArrayEmu extends TIntBufferOverArray implements HasArrayBufferView {
 
     @Emulate
-    Int8ArrayWrapper backupArray;
+    Int32ArrayWrapper backupArray;
     @Emulate
     int positionCache;
     @Emulate
     int remainingCache;
 
-    public ByteBufferImplEmu(int start, int capacity, byte[] array, int position, int limit, boolean direct, boolean readOnly) {
-        super(start, capacity, array, position, limit, direct, readOnly);
+    public IntBufferOverArrayEmu(int start, int capacity, int[] array, int position, int limit, boolean readOnly) {
+        super(start, capacity, array, position, limit, readOnly);
     }
 
     @Override
     @Emulate
     public ArrayBufferViewWrapper getArrayBufferView() {
-        Int8ArrayWrapper int8Array = (Int8ArrayWrapper)getOriginalArrayBufferView();
+        Int32ArrayWrapper originalBuffer = (Int32ArrayWrapper)getOriginalArrayBufferView();
         int position1 = position();
         int remaining1 = remaining();
         if(backupArray == null || positionCache != position1 || remaining1 != remainingCache) {
             positionCache = position1;
             remainingCache = remaining1;
-            backupArray = int8Array.subarray(position1, remaining1);
+            backupArray = originalBuffer.subarray(position1, remaining1);
         }
         return backupArray;
     }
@@ -37,14 +36,12 @@ public abstract class ByteBufferImplEmu extends TByteBufferImpl implements HasAr
     @Override
     @Emulate
     public ArrayBufferViewWrapper getOriginalArrayBufferView() {
-        Object array = array();
-        Int8ArrayWrapper int8Array = TypedArrays.getArrayBufferView((JSObject)array);
-        return int8Array;
+        return TypedArrays.getTypedArray(array);
     }
 
     @Override
     @Emulate
     public int getElementSize() {
-        return 1;
+        return 4;
     }
 }

--- a/backends/backend-teavm/emu/org/teavm/classlib/java/nio/IntBufferOverByteBufferEmu.java
+++ b/backends/backend-teavm/emu/org/teavm/classlib/java/nio/IntBufferOverByteBufferEmu.java
@@ -1,10 +1,23 @@
 package org.teavm.classlib.java.nio;
 
+import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.ArrayBufferViewWrapper;
+import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.Int32ArrayWrapper;
 import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.Int8ArrayWrapper;
+import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.TypedArrays;
 import com.github.xpenatan.gdx.backends.teavm.gen.Emulate;
 
 @Emulate(valueStr = "java.nio.IntBufferOverByteBuffer", updateCode = true)
 public abstract class IntBufferOverByteBufferEmu extends TIntBufferOverByteBuffer implements HasArrayBufferView {
+
+    @Emulate
+    Int32ArrayWrapper backupArray;
+    @Emulate
+    Int32ArrayWrapper intArray;
+    @Emulate
+    int positionCache;
+    @Emulate
+    int remainingCache;
+
 
     public IntBufferOverByteBufferEmu(int start, int capacity, TByteBufferImpl byteBuffer, int position, int limit, boolean readOnly) {
         super(start, capacity, byteBuffer, position, limit, readOnly);
@@ -12,9 +25,27 @@ public abstract class IntBufferOverByteBufferEmu extends TIntBufferOverByteBuffe
 
     @Override
     @Emulate
-    public Int8ArrayWrapper getTypedArray() {
+    public ArrayBufferViewWrapper getArrayBufferView() {
+        // Int8Array
+        Int8ArrayWrapper int8Array = (Int8ArrayWrapper)getOriginalArrayBufferView();
+        if(intArray == null) {
+            intArray = TypedArrays.createInt32Array(int8Array.getBuffer());
+        }
+        int position1 = position();
+        int remaining1 = remaining();
+        if(backupArray == null || positionCache != position1 || remaining1 != remainingCache) {
+            positionCache = position1;
+            remainingCache = remaining1;
+            backupArray = intArray.subarray(position1, remaining1);
+        }
+        return backupArray;
+    }
+
+    @Override
+    @Emulate
+    public ArrayBufferViewWrapper getOriginalArrayBufferView() {
         HasArrayBufferView buff = (HasArrayBufferView)byteByffer;
-        return buff.getTypedArray();
+        return buff.getOriginalArrayBufferView();
     }
 
     @Override

--- a/backends/backend-teavm/emu/org/teavm/classlib/java/nio/ShortBufferOverArrayEmu.java
+++ b/backends/backend-teavm/emu/org/teavm/classlib/java/nio/ShortBufferOverArrayEmu.java
@@ -1,35 +1,34 @@
 package org.teavm.classlib.java.nio;
 
 import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.ArrayBufferViewWrapper;
-import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.Int8ArrayWrapper;
+import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.Int16ArrayWrapper;
 import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.TypedArrays;
 import com.github.xpenatan.gdx.backends.teavm.gen.Emulate;
-import org.teavm.jso.JSObject;
 
-@Emulate(valueStr = "java.nio.ByteBufferImpl", updateCode = true)
-public abstract class ByteBufferImplEmu extends TByteBufferImpl implements HasArrayBufferView {
+@Emulate(valueStr = "java.nio.TShortBufferOverArray", updateCode = true)
+public abstract class ShortBufferOverArrayEmu extends TShortBufferOverArray implements HasArrayBufferView {
 
     @Emulate
-    Int8ArrayWrapper backupArray;
+    Int16ArrayWrapper backupArray;
     @Emulate
     int positionCache;
     @Emulate
     int remainingCache;
 
-    public ByteBufferImplEmu(int start, int capacity, byte[] array, int position, int limit, boolean direct, boolean readOnly) {
-        super(start, capacity, array, position, limit, direct, readOnly);
+    public ShortBufferOverArrayEmu(int start, int capacity, short[] array, int position, int limit, boolean readOnly) {
+        super(start, capacity, array, position, limit, readOnly);
     }
 
     @Override
     @Emulate
     public ArrayBufferViewWrapper getArrayBufferView() {
-        Int8ArrayWrapper int8Array = (Int8ArrayWrapper)getOriginalArrayBufferView();
+        Int16ArrayWrapper originalBuffer = (Int16ArrayWrapper)getOriginalArrayBufferView();
         int position1 = position();
         int remaining1 = remaining();
         if(backupArray == null || positionCache != position1 || remaining1 != remainingCache) {
             positionCache = position1;
             remainingCache = remaining1;
-            backupArray = int8Array.subarray(position1, remaining1);
+            backupArray = originalBuffer.subarray(position1, remaining1);
         }
         return backupArray;
     }
@@ -37,14 +36,12 @@ public abstract class ByteBufferImplEmu extends TByteBufferImpl implements HasAr
     @Override
     @Emulate
     public ArrayBufferViewWrapper getOriginalArrayBufferView() {
-        Object array = array();
-        Int8ArrayWrapper int8Array = TypedArrays.getArrayBufferView((JSObject)array);
-        return int8Array;
+        return TypedArrays.getTypedArray(array);
     }
 
     @Override
     @Emulate
     public int getElementSize() {
-        return 1;
+        return 2;
     }
 }

--- a/backends/backend-teavm/emu/org/teavm/classlib/java/nio/ShortBufferOverByteBufferEmu.java
+++ b/backends/backend-teavm/emu/org/teavm/classlib/java/nio/ShortBufferOverByteBufferEmu.java
@@ -1,10 +1,22 @@
 package org.teavm.classlib.java.nio;
 
+import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.ArrayBufferViewWrapper;
+import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.Int16ArrayWrapper;
 import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.Int8ArrayWrapper;
+import com.github.xpenatan.gdx.backends.teavm.dom.typedarray.TypedArrays;
 import com.github.xpenatan.gdx.backends.teavm.gen.Emulate;
 
 @Emulate(valueStr = "java.nio.ShortBufferOverByteBuffer", updateCode = true)
 public abstract class ShortBufferOverByteBufferEmu extends TShortBufferOverByteBuffer implements HasArrayBufferView {
+
+    @Emulate
+    Int16ArrayWrapper backupArray;
+    @Emulate
+    Int16ArrayWrapper shortArray;
+    @Emulate
+    int positionCache;
+    @Emulate
+    int remainingCache;
 
     public ShortBufferOverByteBufferEmu(int start, int capacity, TByteBufferImpl byteBuffer, int position, int limit, boolean readOnly) {
         super(start, capacity, byteBuffer, position, limit, readOnly);
@@ -12,9 +24,27 @@ public abstract class ShortBufferOverByteBufferEmu extends TShortBufferOverByteB
 
     @Override
     @Emulate
-    public Int8ArrayWrapper getTypedArray() {
+    public ArrayBufferViewWrapper getArrayBufferView() {
+        // Int8Array
+        Int8ArrayWrapper int8Array = (Int8ArrayWrapper)getOriginalArrayBufferView();
+        if(shortArray == null) {
+            shortArray = TypedArrays.createInt16Array(int8Array.getBuffer());
+        }
+        int position1 = position();
+        int remaining1 = remaining();
+        if(backupArray == null || positionCache != position1 || remaining1 != remainingCache) {
+            positionCache = position1;
+            remainingCache = remaining1;
+            backupArray = shortArray.subarray(position1, remaining1);
+        }
+        return backupArray;
+    }
+
+    @Override
+    @Emulate
+    public ArrayBufferViewWrapper getOriginalArrayBufferView() {
         HasArrayBufferView buff = (HasArrayBufferView)byteByffer;
-        return buff.getTypedArray();
+        return buff.getOriginalArrayBufferView();
     }
 
     @Override

--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/TeaGL20.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/TeaGL20.java
@@ -72,16 +72,6 @@ public class TeaGL20 implements GL20 {
         this.gl.pixelStorei(WebGLRenderingContextWrapper.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 0);
     }
 
-    public Float32ArrayWrapper copy(FloatBuffer buffer) {
-        ArrayBufferViewWrapper typedArray = TypedArrays.getTypedArray(buffer);
-        return TypedArrays.createFloat32Array(typedArray.getBuffer(), buffer.position(), buffer.remaining());
-    }
-
-    public Int32ArrayWrapper copy(IntBuffer buffer) {
-        ArrayBufferViewWrapper typedArray = TypedArrays.getTypedArray(buffer);
-        return TypedArrays.createInt32Array(typedArray.getBuffer(), buffer.position(), buffer.remaining());
-    }
-
     protected WebGLUniformLocationWrapper getUniformLocation(int location) {
         return uniforms.get(currProgram).get(location);
     }
@@ -151,51 +141,19 @@ public class TeaGL20 implements GL20 {
 
     @Override
     public void glBufferData(int target, int size, Buffer data, int usage) {
-        if(data instanceof FloatBuffer) {
-            ArrayBufferViewWrapper typedArray = TypedArrays.getTypedArray((FloatBuffer)data);
-            gl.bufferData(target, typedArray, usage);
-        }
-        else if(data instanceof IntBuffer) {
-            ArrayBufferViewWrapper typedArray = TypedArrays.getTypedArray((IntBuffer)data);
-            gl.bufferData(target, typedArray, usage);
-        }
-        else if(data instanceof ShortBuffer) {
-            ArrayBufferViewWrapper typedArray = TypedArrays.getTypedArray((ShortBuffer)data);
-            gl.bufferData(target, typedArray, usage);
-        }
-        else if(data instanceof ByteBuffer) {
-            ArrayBufferViewWrapper typedArray = TypedArrays.getTypedArray((ByteBuffer)data);
-            gl.bufferData(target, typedArray, usage);
-        }
-        else if(data == null) {
+        if(data == null) {
             gl.bufferData(target, size, usage);
         }
         else {
-            throw new GdxRuntimeException("Can only cope with FloatBuffer and ShortBuffer at the moment");
+            ArrayBufferViewWrapper typedArray = TypedArrays.getTypedArray(data);
+            gl.bufferData(target, typedArray, usage);
         }
     }
 
     @Override
     public void glBufferSubData(int target, int offset, int size, Buffer data) {
-        if(data instanceof FloatBuffer) {
-            ArrayBufferViewWrapper typedArray = TypedArrays.getTypedArray((FloatBuffer)data);
-            gl.bufferSubData(target, offset, typedArray);
-        }
-        else if(data instanceof IntBuffer) {
-            ArrayBufferViewWrapper typedArray = TypedArrays.getTypedArray((IntBuffer)data);
-            gl.bufferSubData(target, offset, typedArray);
-        }
-        else if(data instanceof ShortBuffer) {
-            ArrayBufferViewWrapper typedArray = TypedArrays.getTypedArray((ShortBuffer)data);
-            gl.bufferSubData(target, offset, typedArray);
-        }
-        else if(data instanceof ByteBuffer) {
-            ArrayBufferViewWrapper typedArray = TypedArrays.getTypedArray((ByteBuffer)data);
-            gl.bufferSubData(target, offset, typedArray);
-        }
-        else {
-            throw new GdxRuntimeException("Can only cope with FloatBuffer and ShortBuffer at the moment");
-        }
+        ArrayBufferViewWrapper typedArray = TypedArrays.getTypedArray(data);
+        gl.bufferSubData(target, offset, typedArray);
     }
 
     @Override
@@ -797,29 +755,10 @@ public class TeaGL20 implements GL20 {
             throw new GdxRuntimeException(
                     "Only format RGBA and type UNSIGNED_BYTE are currently supported for glReadPixels(...). Create an issue when you need other formats.");
         }
-        ArrayBufferViewWrapper typedArray = null;
-        if(pixels instanceof ByteBuffer) {
-            typedArray = TypedArrays.getTypedArray((ByteBuffer)pixels);
-        }
-        else if(pixels instanceof FloatBuffer) {
-            typedArray = TypedArrays.getTypedArray((FloatBuffer)pixels);
-        }
-        else if(pixels instanceof ShortBuffer) {
-            typedArray = TypedArrays.getTypedArray((ShortBuffer)pixels);
-        }
-        else if(pixels instanceof IntBuffer) {
-            typedArray = TypedArrays.getTypedArray((IntBuffer)pixels);
-        }
-        else {
-            throw new GdxRuntimeException("Inputed pixels buffer not supported.");
-        }
-
-        // create new ArrayBufferView (4 bytes per pixel)
+        ArrayBufferViewWrapper typedArray = TypedArrays.getTypedArray(pixels);
         int size = 4 * width * height;
         Uint8ArrayWrapper buffer = TypedArrays.createUint8Array(typedArray.getBuffer(), typedArray.getByteOffset(), size);
-
         gl.readPixels(x, y, width, height, format, type, buffer);
-
         pixels.limit(size);
     }
 
@@ -961,7 +900,7 @@ public class TeaGL20 implements GL20 {
     @Override
     public void glUniform1fv(int location, int count, FloatBuffer v) {
         WebGLUniformLocationWrapper loc = getUniformLocation(location);
-        gl.uniform1fv(loc, copy(v));
+        gl.uniform1fv(loc, TypedArrays.getTypedArray(v));
     }
 
     @Override
@@ -979,7 +918,7 @@ public class TeaGL20 implements GL20 {
     @Override
     public void glUniform1iv(int location, int count, IntBuffer v) {
         WebGLUniformLocationWrapper loc = getUniformLocation(location);
-        gl.uniform1iv(loc, copy(v));
+        gl.uniform1iv(loc, TypedArrays.getTypedArray(v));
     }
 
     @Override
@@ -997,7 +936,7 @@ public class TeaGL20 implements GL20 {
     @Override
     public void glUniform2fv(int location, int count, FloatBuffer v) {
         WebGLUniformLocationWrapper loc = getUniformLocation(location);
-        gl.uniform2fv(loc, copy(v));
+        gl.uniform2fv(loc, TypedArrays.getTypedArray(v));
     }
 
     @Override
@@ -1015,7 +954,7 @@ public class TeaGL20 implements GL20 {
     @Override
     public void glUniform2iv(int location, int count, IntBuffer v) {
         WebGLUniformLocationWrapper loc = getUniformLocation(location);
-        gl.uniform2iv(loc, copy(v));
+        gl.uniform2iv(loc, TypedArrays.getTypedArray(v));
     }
 
     @Override
@@ -1033,7 +972,7 @@ public class TeaGL20 implements GL20 {
     @Override
     public void glUniform3fv(int location, int count, FloatBuffer v) {
         WebGLUniformLocationWrapper loc = getUniformLocation(location);
-        gl.uniform3fv(loc, copy(v));
+        gl.uniform3fv(loc, TypedArrays.getTypedArray(v));
     }
 
     @Override
@@ -1051,7 +990,7 @@ public class TeaGL20 implements GL20 {
     @Override
     public void glUniform3iv(int location, int count, IntBuffer v) {
         WebGLUniformLocationWrapper loc = getUniformLocation(location);
-        gl.uniform3iv(loc, copy(v));
+        gl.uniform3iv(loc, TypedArrays.getTypedArray(v));
     }
 
     @Override
@@ -1069,7 +1008,7 @@ public class TeaGL20 implements GL20 {
     @Override
     public void glUniform4fv(int location, int count, FloatBuffer v) {
         WebGLUniformLocationWrapper loc = getUniformLocation(location);
-        gl.uniform4fv(loc, copy(v));
+        gl.uniform4fv(loc, TypedArrays.getTypedArray(v));
     }
 
     @Override
@@ -1087,7 +1026,7 @@ public class TeaGL20 implements GL20 {
     @Override
     public void glUniform4iv(int location, int count, IntBuffer v) {
         WebGLUniformLocationWrapper loc = getUniformLocation(location);
-        gl.uniform4iv(loc, copy(v));
+        gl.uniform4iv(loc, TypedArrays.getTypedArray(v));
     }
 
     @Override
@@ -1099,7 +1038,7 @@ public class TeaGL20 implements GL20 {
     @Override
     public void glUniformMatrix2fv(int location, int count, boolean transpose, FloatBuffer value) {
         WebGLUniformLocationWrapper loc = getUniformLocation(location);
-        gl.uniformMatrix2fv(loc, transpose, copy(value));
+        gl.uniformMatrix2fv(loc, transpose, TypedArrays.getTypedArray(value));
     }
 
     @Override
@@ -1111,7 +1050,7 @@ public class TeaGL20 implements GL20 {
     @Override
     public void glUniformMatrix3fv(int location, int count, boolean transpose, FloatBuffer value) {
         WebGLUniformLocationWrapper loc = getUniformLocation(location);
-        gl.uniformMatrix3fv(loc, transpose, copy(value));
+        gl.uniformMatrix3fv(loc, transpose, TypedArrays.getTypedArray(value));
     }
 
     @Override
@@ -1123,7 +1062,7 @@ public class TeaGL20 implements GL20 {
     @Override
     public void glUniformMatrix4fv(int location, int count, boolean transpose, FloatBuffer value) {
         WebGLUniformLocationWrapper loc = getUniformLocation(location);
-        gl.uniformMatrix4fv(loc, transpose, copy(value));
+        gl.uniformMatrix4fv(loc, transpose, TypedArrays.getTypedArray(value));
     }
 
     @Override
@@ -1150,7 +1089,7 @@ public class TeaGL20 implements GL20 {
 
     @Override
     public void glVertexAttrib1fv(int indx, FloatBuffer values) {
-        gl.vertexAttrib1fv(indx, copy(values));
+        gl.vertexAttrib1fv(indx, TypedArrays.getTypedArray(values));
     }
 
     @Override
@@ -1160,7 +1099,7 @@ public class TeaGL20 implements GL20 {
 
     @Override
     public void glVertexAttrib2fv(int indx, FloatBuffer values) {
-        gl.vertexAttrib2fv(indx, copy(values));
+        gl.vertexAttrib2fv(indx, TypedArrays.getTypedArray(values));
     }
 
     @Override
@@ -1170,7 +1109,7 @@ public class TeaGL20 implements GL20 {
 
     @Override
     public void glVertexAttrib3fv(int indx, FloatBuffer values) {
-        gl.vertexAttrib3fv(indx, copy(values));
+        gl.vertexAttrib3fv(indx, TypedArrays.getTypedArray(values));
     }
 
     @Override
@@ -1180,7 +1119,7 @@ public class TeaGL20 implements GL20 {
 
     @Override
     public void glVertexAttrib4fv(int indx, FloatBuffer values) {
-        gl.vertexAttrib4fv(indx, copy(values));
+        gl.vertexAttrib4fv(indx, TypedArrays.getTypedArray(values));
     }
 
     @Override

--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/TeaGL30.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/TeaGL30.java
@@ -111,17 +111,17 @@ public class TeaGL30 extends TeaGL20 implements GL30 {
 
     @Override
     public void glClearBufferfv(int buffer, int drawbuffer, FloatBuffer value) {
-        gl.clearBufferfv(buffer, drawbuffer, copy(value));
+        gl.clearBufferfv(buffer, drawbuffer, TypedArrays.getTypedArray(value));
     }
 
     @Override
     public void glClearBufferiv(int buffer, int drawbuffer, IntBuffer value) {
-        gl.clearBufferiv(buffer, drawbuffer, copy(value));
+        gl.clearBufferiv(buffer, drawbuffer, TypedArrays.getTypedArray(value));
     }
 
     @Override
     public void glClearBufferuiv(int buffer, int drawbuffer, IntBuffer value) {
-        gl.clearBufferuiv(buffer, drawbuffer, copy(value));
+        gl.clearBufferuiv(buffer, drawbuffer, TypedArrays.getTypedArray(value));
     }
 
     @Override
@@ -230,7 +230,7 @@ public class TeaGL30 extends TeaGL20 implements GL30 {
     @Override
     public void glDrawBuffers(int n, IntBuffer bufs) {
         int startPosition = bufs.position();
-        gl.drawBuffers(copy((IntBuffer)bufs).subarray(0, n));
+        gl.drawBuffers(TypedArrays.getTypedArray(bufs).subarray(0, n));
         bufs.position(startPosition);
     }
 
@@ -389,15 +389,15 @@ public class TeaGL30 extends TeaGL20 implements GL30 {
     }
 
     @Override
-    public void glGetActiveUniformsiv(int program, int uniformCount, IntBuffer uniformIndices, int pname, IntBuffer params) {
+        public void glGetActiveUniformsiv(int program, int uniformCount, IntBuffer uniformIndices, int pname, IntBuffer params) {
         if(pname == GL30.GL_UNIFORM_IS_ROW_MAJOR) {
-            JSArray<Boolean> arr = gl.getActiveUniformsb(programs.get(program), copy(uniformIndices).subarray(0, uniformCount), pname);
+            JSArray<Boolean> arr = gl.getActiveUniformsb(programs.get(program), TypedArrays.getTypedArray(uniformIndices).subarray(0, uniformCount), pname);
             for(int i = 0; i < uniformCount; i++) {
                 params.put(i, arr.get(i) ? GL20.GL_TRUE : GL20.GL_FALSE);
             }
         }
         else {
-            JSArray<Integer> arr = gl.getActiveUniformsi(programs.get(program), copy(uniformIndices).subarray(0, uniformCount), pname);
+            JSArray<Integer> arr = gl.getActiveUniformsi(programs.get(program), TypedArrays.getTypedArray(uniformIndices).subarray(0, uniformCount), pname);
             for(int i = 0; i < uniformCount; i++) {
                 params.put(i, arr.get(i));
             }
@@ -638,7 +638,7 @@ public class TeaGL30 extends TeaGL20 implements GL30 {
     @Override
     public void glInvalidateFramebuffer(int target, int numAttachments, IntBuffer attachments) {
         int startPosition = attachments.position();
-        gl.invalidateFramebuffer(target, copy((IntBuffer)attachments).subarray(0, numAttachments));
+        gl.invalidateFramebuffer(target, TypedArrays.getTypedArray(attachments).subarray(0, numAttachments));
         attachments.position(startPosition);
     }
 
@@ -646,7 +646,7 @@ public class TeaGL30 extends TeaGL20 implements GL30 {
     public void glInvalidateSubFramebuffer(int target, int numAttachments, IntBuffer attachments, int x, int y, int width,
                                            int height) {
         int startPosition = attachments.position();
-        gl.invalidateSubFramebuffer(target, copy((IntBuffer)attachments).subarray(0, numAttachments), x, y, width, height);
+        gl.invalidateSubFramebuffer(target, TypedArrays.getTypedArray(attachments).subarray(0, numAttachments), x, y, width, height);
         attachments.position(startPosition);
     }
 
@@ -817,37 +817,37 @@ public class TeaGL30 extends TeaGL20 implements GL30 {
     @Override
     public void glUniformMatrix2x3fv(int location, int count, boolean transpose, FloatBuffer value) {
         WebGLUniformLocationWrapper loc = getUniformLocation(location);
-        gl.uniformMatrix2x3fv(loc, transpose, copy(value));
+        gl.uniformMatrix2x3fv(loc, transpose, TypedArrays.getTypedArray(value));
     }
 
     @Override
     public void glUniformMatrix2x4fv(int location, int count, boolean transpose, FloatBuffer value) {
         WebGLUniformLocationWrapper loc = getUniformLocation(location);
-        gl.uniformMatrix2x4fv(loc, transpose, copy(value), 0, count);
+        gl.uniformMatrix2x4fv(loc, transpose, TypedArrays.getTypedArray(value), 0, count);
     }
 
     @Override
     public void glUniformMatrix3x2fv(int location, int count, boolean transpose, FloatBuffer value) {
         WebGLUniformLocationWrapper loc = getUniformLocation(location);
-        gl.uniformMatrix3x2fv(loc, transpose, copy(value), 0, count);
+        gl.uniformMatrix3x2fv(loc, transpose, TypedArrays.getTypedArray(value), 0, count);
     }
 
     @Override
     public void glUniformMatrix3x4fv(int location, int count, boolean transpose, FloatBuffer value) {
         WebGLUniformLocationWrapper loc = getUniformLocation(location);
-        gl.uniformMatrix3x4fv(loc, transpose, copy(value), 0, count);
+        gl.uniformMatrix3x4fv(loc, transpose, TypedArrays.getTypedArray(value), 0, count);
     }
 
     @Override
     public void glUniformMatrix4x2fv(int location, int count, boolean transpose, FloatBuffer value) {
         WebGLUniformLocationWrapper loc = getUniformLocation(location);
-        gl.uniformMatrix4x2fv(loc, transpose, copy(value), 0, count);
+        gl.uniformMatrix4x2fv(loc, transpose, TypedArrays.getTypedArray(value), 0, count);
     }
 
     @Override
     public void glUniformMatrix4x3fv(int location, int count, boolean transpose, FloatBuffer value) {
         WebGLUniformLocationWrapper loc = getUniformLocation(location);
-        gl.uniformMatrix4x3fv(loc, transpose, copy(value), 0, count);
+        gl.uniformMatrix4x3fv(loc, transpose, TypedArrays.getTypedArray(value), 0, count);
     }
 
     @Override

--- a/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/dom/typedarray/TypedArrays.java
+++ b/backends/backend-teavm/src/main/java/com/github/xpenatan/gdx/backends/teavm/dom/typedarray/TypedArrays.java
@@ -1,5 +1,6 @@
 package com.github.xpenatan.gdx.backends.teavm.dom.typedarray;
 
+import com.badlogic.gdx.utils.GdxRuntimeException;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
@@ -163,70 +164,68 @@ public class TypedArrays {
         return byteArray;
     }
 
-    public static ArrayBufferViewWrapper getTypedArray(ByteBuffer buffer) {
-        ArrayBufferViewWrapper bufferView = getInt8Array(buffer);
-        if(bufferView != null) {
-            return bufferView;
+    public static ArrayBufferViewWrapper getTypedArray(Buffer buffer) {
+        if(buffer instanceof HasArrayBufferView) {
+            return ((HasArrayBufferView)buffer).getArrayBufferView();
         }
-        byte[] array = buffer.array();
-        ArrayBufferViewWrapper arrayBuffer = getTypedArray(array);
-        return arrayBuffer;
+        else {
+            throw new GdxRuntimeException("Buffer should have ArrayBufferView interface");
+        }
     }
 
-    public static ArrayBufferViewWrapper getTypedArray(ShortBuffer buffer) {
-        ArrayBufferViewWrapper bufferView = getInt8Array(buffer);
-        if(bufferView != null) {
-            return bufferView;
+    public static Int8ArrayWrapper getTypedArray(ByteBuffer buffer) {
+        if(buffer instanceof HasArrayBufferView) {
+            return (Int8ArrayWrapper)((HasArrayBufferView)buffer).getArrayBufferView();
         }
-        short[] array = buffer.array();
-        ArrayBufferViewWrapper arrayBuffer = getTypedArray(array);
-        return arrayBuffer;
+        else {
+            throw new GdxRuntimeException("Buffer should have ArrayBufferView interface");
+        }
     }
 
-    public static ArrayBufferViewWrapper getTypedArray(IntBuffer buffer) {
-        ArrayBufferViewWrapper bufferView = getInt8Array(buffer);
-        if(bufferView != null) {
-            return bufferView;
+    public static Int16ArrayWrapper getTypedArray(ShortBuffer buffer) {
+        if(buffer instanceof HasArrayBufferView) {
+            return (Int16ArrayWrapper)((HasArrayBufferView)buffer).getArrayBufferView();
         }
-        int[] array = buffer.array();
-        ArrayBufferViewWrapper arrayBuffer = getTypedArray(array);
-        return arrayBuffer;
+        else {
+            throw new GdxRuntimeException("Buffer should have ArrayBufferView interface");
+        }
     }
 
-    public static ArrayBufferViewWrapper getTypedArray(FloatBuffer buffer) {
-        ArrayBufferViewWrapper bufferView = getInt8Array(buffer);
-        if(bufferView != null) {
-            return bufferView;
+    public static Int32ArrayWrapper getTypedArray(IntBuffer buffer) {
+        if(buffer instanceof HasArrayBufferView) {
+            return (Int32ArrayWrapper)((HasArrayBufferView)buffer).getArrayBufferView();
         }
-        float[] array = buffer.array();
-        ArrayBufferViewWrapper arrayBuffer = getTypedArray(array);
-        return arrayBuffer;
+        else {
+            throw new GdxRuntimeException("Buffer should have ArrayBufferView interface");
+        }
+    }
+
+    public static Float32ArrayWrapper getTypedArray(FloatBuffer buffer) {
+        if(buffer instanceof HasArrayBufferView) {
+            return (Float32ArrayWrapper)((HasArrayBufferView)buffer).getArrayBufferView();
+        }
+        else {
+            throw new GdxRuntimeException("Buffer should have ArrayBufferView interface");
+        }
     }
 
     @JSBody(params = {"buffer"}, script = "" +
             "return buffer;")
-    public static native ArrayBufferViewWrapper getTypedArray(@JSByRef() byte[] buffer);
+    public static native Int8ArrayWrapper getTypedArray(@JSByRef() byte[] buffer);
 
     @JSBody(params = {"buffer"}, script = "" +
             "return buffer;")
-    private static native ArrayBufferViewWrapper getTypedArray(@JSByRef() int[] buffer);
+    public static native Int32ArrayWrapper getTypedArray(@JSByRef() int[] buffer);
 
     @JSBody(params = {"buffer"}, script = "" +
             "return buffer;")
-    private static native ArrayBufferViewWrapper getTypedArray(@JSByRef() float[] buffer);
+    public static native Int16ArrayWrapper getTypedArray(@JSByRef() short[] buffer);
 
     @JSBody(params = {"buffer"}, script = "" +
             "return buffer;")
-    private static native ArrayBufferViewWrapper getTypedArray(@JSByRef() short[] buffer);
+    public static native Float32ArrayWrapper getTypedArray(@JSByRef() float[] buffer);
 
     @org.teavm.jso.JSBody(params = {"array"}, script = "" +
             "return array.data;")
     public static native Int8ArrayWrapper getArrayBufferView(JSObject array);
-
-    public static Int8ArrayWrapper getInt8Array(Buffer buffer) {
-        if(buffer instanceof HasArrayBufferView) {
-            return ((HasArrayBufferView)buffer).getTypedArray();
-        }
-        return null;
-    }
 }


### PR DESCRIPTION
This is an attempt to improve GL calls by converting Java buffers to Javascript buffers.

It tries to cache the javascript buffer and not copy it every frame.

To test it you can open these tests.

https://xpenatan.github.io/ApollonianGasket/teavm-b9/
https://xpenatan.github.io/ApollonianGasket/teavm-1.0.1/
https://xpenatan.github.io/ApollonianGasket/teavm-snapshot/

They share the same random seed so refreshing will open the same generated picture.

![image](https://github.com/user-attachments/assets/6f8962a1-0168-48de-b7e0-dae0a6fb35a0)
![image](https://github.com/user-attachments/assets/1448c6ab-0d8a-47e5-80d6-44c9d2aa2765)
![image](https://github.com/user-attachments/assets/e61cf904-85b5-486b-a811-9319e4ee9bb3)
