### PR TITLE
Fix SCM URLs in Maven publishing

### DIFF
--- a/buildSrc/src/main/kotlin/publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/publish.gradle.kts
@@ -52,9 +52,9 @@ configure(libProjects) {
                         }
                     }
                     scm {
-                        connection.set("scm:git:git://https://github.com/xpenatan/gdx-teavm.git")
-                        developerConnection.set("scm:git:ssh://https://github.com/xpenatan/gdx-teavm.git")
-                        url.set("http://https://github.com/xpenatan/gdx-teavm/tree/master")
+                        connection.set("scm:git:https://github.com/xpenatan/gdx-teavm.git")
+                        developerConnection.set("scm:git:https://github.com/xpenatan/gdx-teavm.git")
+                        url.set("https://github.com/xpenatan/gdx-teavm")
                     }
                     licenses {
                         license {


### PR DESCRIPTION
The URLs seem to contain a copy/paste error. I think this is the reason your project is not appearing on [deps.dev](https://deps.dev).