### PR TITLE
Fix WebGL buffer uploads to respect buffer ranges

### DIFF
--- a/backends/backend-web/src/main/java/com/github/xpenatan/gdx/teavm/backends/web/WebGL20.java
+++ b/backends/backend-web/src/main/java/com/github/xpenatan/gdx/teavm/backends/web/WebGL20.java
@@ -142,14 +142,14 @@ public class WebGL20 implements GL20 {
             gl.bufferData(target, size, usage);
         }
         else {
-            ArrayBufferView typedArray = TypedArrays.getTypedArray(data);
+            ArrayBufferView typedArray = TypedArrays.getTypedArrayRange(data);
             gl.bufferData(target, typedArray, usage);
         }
     }
 
     @Override
     public void glBufferSubData(int target, int offset, int size, Buffer data) {
-        ArrayBufferView typedArray = TypedArrays.getTypedArray(data);
+        ArrayBufferView typedArray = TypedArrays.getTypedArrayRange(data);
         gl.bufferSubData(target, offset, typedArray);
     }
 

--- a/backends/backend-web/src/main/java/com/github/xpenatan/gdx/teavm/backends/web/dom/typedarray/TypedArrays.java
+++ b/backends/backend-web/src/main/java/com/github/xpenatan/gdx/teavm/backends/web/dom/typedarray/TypedArrays.java
@@ -57,6 +57,100 @@ public class TypedArrays {
         throw new GdxRuntimeException("No support for buffer " + buffer.getClass());
     }
 
+    /**
+     * Returns a byte view covering the buffer's active range, from its current position to its limit.
+     * The source buffer's position, limit, and mark are not changed.
+     */
+    public static Int8Array getTypedArrayRange(Buffer buffer) {
+        ArrayBufferView typedArray = getTypedArray(getConversionBuffer(buffer));
+        return new Int8Array(typedArray.getBuffer(), typedArray.getByteOffset() + getRangeByteOffset(buffer),
+                getRangeByteLength(buffer));
+    }
+
+    static Buffer getConversionBuffer(Buffer buffer) {
+        if(PlatformDetector.isJavaScript() || buffer.isDirect() || hasArray(buffer)) {
+            return buffer;
+        }
+        // The Wasm-GC fallback for heap views without an accessible array copies data by temporarily rewinding its
+        // input. Convert a duplicate so that operation cannot discard the caller's mark.
+        if(buffer instanceof ByteBuffer) {
+            return ((ByteBuffer)buffer).duplicate();
+        }
+        else if(buffer instanceof ShortBuffer) {
+            return ((ShortBuffer)buffer).duplicate();
+        }
+        else if(buffer instanceof IntBuffer) {
+            return ((IntBuffer)buffer).duplicate();
+        }
+        else if(buffer instanceof FloatBuffer) {
+            return ((FloatBuffer)buffer).duplicate();
+        }
+        throw new GdxRuntimeException("No support for buffer " + buffer.getClass());
+    }
+
+    private static boolean hasArray(Buffer buffer) {
+        if(buffer instanceof ByteBuffer) {
+            return ((ByteBuffer)buffer).hasArray();
+        }
+        else if(buffer instanceof ShortBuffer) {
+            return ((ShortBuffer)buffer).hasArray();
+        }
+        else if(buffer instanceof IntBuffer) {
+            return ((IntBuffer)buffer).hasArray();
+        }
+        else if(buffer instanceof FloatBuffer) {
+            return ((FloatBuffer)buffer).hasArray();
+        }
+        throw new GdxRuntimeException("No support for buffer " + buffer.getClass());
+    }
+
+    static int getRangeByteOffset(Buffer buffer) {
+        int position = buffer.position();
+        // JS and direct-buffer views already start at a sliced buffer's base. The heap fallback copies the
+        // complete backing array, so its array offset must be included here.
+        if(!PlatformDetector.isJavaScript() && !buffer.isDirect()) {
+            position += getArrayOffset(buffer);
+        }
+        return position * getElementSize(buffer);
+    }
+
+    static int getRangeByteLength(Buffer buffer) {
+        return buffer.remaining() * getElementSize(buffer);
+    }
+
+    private static int getElementSize(Buffer buffer) {
+        if(buffer instanceof ByteBuffer) {
+            return 1;
+        }
+        else if(buffer instanceof ShortBuffer) {
+            return 2;
+        }
+        else if(buffer instanceof IntBuffer || buffer instanceof FloatBuffer) {
+            return 4;
+        }
+        throw new GdxRuntimeException("No support for buffer " + buffer.getClass());
+    }
+
+    private static int getArrayOffset(Buffer buffer) {
+        if(buffer instanceof ByteBuffer) {
+            ByteBuffer byteBuffer = (ByteBuffer)buffer;
+            return byteBuffer.hasArray() ? byteBuffer.arrayOffset() : 0;
+        }
+        else if(buffer instanceof ShortBuffer) {
+            ShortBuffer shortBuffer = (ShortBuffer)buffer;
+            return shortBuffer.hasArray() ? shortBuffer.arrayOffset() : 0;
+        }
+        else if(buffer instanceof IntBuffer) {
+            IntBuffer intBuffer = (IntBuffer)buffer;
+            return intBuffer.hasArray() ? intBuffer.arrayOffset() : 0;
+        }
+        else if(buffer instanceof FloatBuffer) {
+            FloatBuffer floatBuffer = (FloatBuffer)buffer;
+            return floatBuffer.hasArray() ? floatBuffer.arrayOffset() : 0;
+        }
+        throw new GdxRuntimeException("No support for buffer " + buffer.getClass());
+    }
+
     public static Int8Array getInt8Array(Buffer buff) {
         if(PlatformDetector.isJavaScript() || buff.isDirect()) {
             return Int8Array.fromJavaBuffer(buff);

--- a/backends/backend-web/src/main/java/com/github/xpenatan/gdx/teavm/backends/web/dom/typedarray/TypedArrays.java
+++ b/backends/backend-web/src/main/java/com/github/xpenatan/gdx/teavm/backends/web/dom/typedarray/TypedArrays.java
@@ -7,6 +7,10 @@ import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
 import org.teavm.classlib.PlatformDetector;
+import org.teavm.jso.JSBody;
+import org.teavm.jso.JSObject;
+import org.teavm.jso.core.JSWeakMap;
+import org.teavm.jso.typedarrays.ArrayBuffer;
 import org.teavm.jso.typedarrays.ArrayBufferView;
 import org.teavm.jso.typedarrays.Float32Array;
 import org.teavm.jso.typedarrays.Int16Array;
@@ -20,6 +24,10 @@ import org.teavm.jso.typedarrays.Uint8Array;
  * @author xpenatan
  */
 public class TypedArrays {
+
+    // Wasm direct buffers share one backing ArrayBuffer, so retain several recent ranges without growing unbounded.
+    private static final int MAX_CACHED_RANGES = 16;
+    private static final JSWeakMap<ArrayBuffer, JSObject> typedArrayRangeCache = new JSWeakMap<>();
 
     // Obtain the array reference from ArrayBufferView
     public static byte[] toByteArray(TypedArray array) {
@@ -59,13 +67,40 @@ public class TypedArrays {
 
     /**
      * Returns a byte view covering the buffer's active range, from its current position to its limit.
-     * The source buffer's position, limit, and mark are not changed.
+     * Reuses the source view when it already covers that range and otherwise caches recent partial ranges for each
+     * backing buffer. The source buffer's position, limit, and mark are not changed.
      */
-    public static Int8Array getTypedArrayRange(Buffer buffer) {
+    public static ArrayBufferView getTypedArrayRange(Buffer buffer) {
         ArrayBufferView typedArray = getTypedArray(getConversionBuffer(buffer));
-        return new Int8Array(typedArray.getBuffer(), typedArray.getByteOffset() + getRangeByteOffset(buffer),
-                getRangeByteLength(buffer));
+        int byteOffset = typedArray.getByteOffset() + getRangeByteOffset(buffer);
+        int byteLength = getRangeByteLength(buffer);
+        if(typedArray.getByteOffset() == byteOffset && typedArray.getByteLength() == byteLength) {
+            return typedArray;
+        }
+        ArrayBuffer arrayBuffer = typedArray.getBuffer();
+        return getOrCreateRange(typedArrayRangeCache, arrayBuffer, byteOffset, byteLength, MAX_CACHED_RANGES);
     }
+
+    // A Wasm memory growth replaces arrayBuffer, so its old cache becomes unreachable without explicit invalidation.
+    @JSBody(params = { "cache", "arrayBuffer", "byteOffset", "byteLength", "maxRanges" }, script =
+            "var ranges = cache.get(arrayBuffer);"
+                    + " if (ranges === undefined) { ranges = []; cache.set(arrayBuffer, ranges); }"
+                    + " for (var i = ranges.length - 1; i >= 0; i--) {"
+                    + "  var range = ranges[i];"
+                    + "  if (range.byteOffset === byteOffset && range.byteLength === byteLength) {"
+                    + "   for (var j = i; j < ranges.length - 1; j++) ranges[j] = ranges[j + 1];"
+                    + "   ranges[ranges.length - 1] = range; return range;"
+                    + "  }"
+                    + " }"
+                    + " var range = new Int8Array(arrayBuffer, byteOffset, byteLength);"
+                    + " if (ranges.length < maxRanges) ranges.push(range);"
+                    + " else {"
+                    + "  for (var i = 1; i < ranges.length; i++) ranges[i - 1] = ranges[i];"
+                    + "  ranges[ranges.length - 1] = range;"
+                    + " }"
+                    + " return range;")
+    private static native Int8Array getOrCreateRange(JSWeakMap<ArrayBuffer, JSObject> cache, ArrayBuffer arrayBuffer,
+            int byteOffset, int byteLength, int maxRanges);
 
     static Buffer getConversionBuffer(Buffer buffer) {
         if(PlatformDetector.isJavaScript() || buffer.isDirect() || hasArray(buffer)) {

--- a/backends/backend-web/src/test/java/com/github/xpenatan/gdx/teavm/backends/web/dom/typedarray/TypedArraysTest.java
+++ b/backends/backend-web/src/test/java/com/github/xpenatan/gdx/teavm/backends/web/dom/typedarray/TypedArraysTest.java
@@ -1,0 +1,90 @@
+package com.github.xpenatan.gdx.teavm.backends.web.dom.typedarray;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.ShortBuffer;
+import org.junit.Test;
+
+public class TypedArraysTest {
+
+    @Test
+    public void calculatesByteRangeWithoutChangingBufferState() {
+        assertRange(ByteBuffer.allocate(8), 2, 5, 2, 3);
+        assertRange(ShortBuffer.allocate(8), 2, 5, 4, 6);
+        assertRange(IntBuffer.allocate(8), 2, 5, 8, 12);
+        assertRange(FloatBuffer.allocate(8), 2, 5, 8, 12);
+    }
+
+    @Test
+    public void supportsEmptyRangeAtEndOfBuffer() {
+        assertRange(FloatBuffer.allocate(8), 8, 8, 32, 0);
+    }
+
+    @Test
+    public void includesBackingArrayOffsetForSlicedHeapBuffers() {
+        ByteBuffer byteBuffer = ByteBuffer.allocate(8);
+        byteBuffer.position(1);
+        assertRange(byteBuffer.slice(), 2, 5, 3, 3);
+
+        ShortBuffer shortBuffer = ShortBuffer.allocate(8);
+        shortBuffer.position(1);
+        assertRange(shortBuffer.slice(), 2, 5, 6, 6);
+
+        IntBuffer intBuffer = IntBuffer.allocate(8);
+        intBuffer.position(1);
+        assertRange(intBuffer.slice(), 2, 5, 12, 12);
+
+        FloatBuffer floatBuffer = FloatBuffer.allocate(8);
+        floatBuffer.position(1);
+        assertRange(floatBuffer.slice(), 2, 5, 12, 12);
+    }
+
+    @Test
+    public void duplicateProtectsSourceStateDuringFallbackConversion() {
+        assertDuplicateProtectsState(ByteBuffer.allocate(16).asReadOnlyBuffer());
+        assertDuplicateProtectsState(ByteBuffer.allocate(32).asShortBuffer());
+        assertDuplicateProtectsState(ByteBuffer.allocate(32).asIntBuffer());
+        assertDuplicateProtectsState(ByteBuffer.allocate(32).asFloatBuffer());
+    }
+
+    @Test
+    public void reusesBuffersWhenConversionDoesNotMutateThem() {
+        ByteBuffer heapBuffer = ByteBuffer.allocate(8);
+        assertThat(TypedArrays.getConversionBuffer(heapBuffer)).isSameInstanceAs(heapBuffer);
+
+        ByteBuffer directBuffer = ByteBuffer.allocateDirect(8);
+        assertThat(TypedArrays.getConversionBuffer(directBuffer)).isSameInstanceAs(directBuffer);
+    }
+
+    private static void assertRange(Buffer buffer, int position, int limit, int bytePosition, int remainingBytes) {
+        buffer.position(position);
+        buffer.limit(limit);
+
+        assertThat(TypedArrays.getRangeByteOffset(buffer)).isEqualTo(bytePosition);
+        assertThat(TypedArrays.getRangeByteLength(buffer)).isEqualTo(remainingBytes);
+        assertThat(buffer.position()).isEqualTo(position);
+        assertThat(buffer.limit()).isEqualTo(limit);
+    }
+
+    private static void assertDuplicateProtectsState(Buffer buffer) {
+        int originalLimit = buffer.capacity() - 1;
+        buffer.limit(originalLimit);
+        buffer.position(1);
+        buffer.mark();
+        buffer.position(2);
+
+        Buffer duplicate = TypedArrays.getConversionBuffer(buffer);
+        assertThat(duplicate).isNotSameInstanceAs(buffer);
+        duplicate.position(0);
+        duplicate.limit(duplicate.capacity());
+
+        assertThat(buffer.position()).isEqualTo(2);
+        assertThat(buffer.limit()).isEqualTo(originalLimit);
+        buffer.reset();
+        assertThat(buffer.position()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## Summary

- upload only the active `position..limit` range of NIO buffers in `glBufferData` and `glBufferSubData`
- preserve sliced heap-buffer offsets on Wasm-GC without changing the caller's position, limit, or mark
- add regression coverage for byte ranges, empty buffers, sliced heap buffers, fallback views, and source-state preservation

## Problem

The WebGL backend currently converts the full backing storage to a typed array. For example, a `FloatBuffer` with capacity 8, position 2, and limit 5 uploads all 32 backing bytes instead of the 12 active bytes.

Besides transferring unrelated data, this can resize a WebGL buffer incorrectly and overwrite more data than requested by a sub-data update.

## Implementation

`TypedArrays.getTypedArrayRange` creates a byte view over the converted buffer using the active range. It accounts for the backing-array offset when Wasm-GC copies a sliced heap buffer's complete array.

The normal JavaScript, direct-buffer, and array-backed paths keep using the original buffer. Only the Wasm-GC fallback for heap views without an accessible array converts a duplicate, because that fallback temporarily rewinds its input and would otherwise invalidate the caller's mark.

The existing null-data allocation path and `size` argument behavior are unchanged.

## Verification

- `./gradlew :backends:backend-web:build`
- generated TeaVM JavaScript and Wasm-GC builds executed in headless Chromium
- 12 runtime variants covering heap, sliced heap, direct, empty, and marked no-array buffer views
- real WebGL2 GPU readback after both `glBufferData` and non-zero-offset `glBufferSubData`

Both generated targets reported `BUFFER_RANGE_PROBE PASS variants=12 mark=preserved`.
