### PR TITLE
Change return type of getNativeScreenDensityNATIVE to double

### DIFF
--- a/backends/backend-web/src/main/java/com/github/xpenatan/gdx/teavm/backends/web/WebGraphics.java
+++ b/backends/backend-web/src/main/java/com/github/xpenatan/gdx/teavm/backends/web/WebGraphics.java
@@ -370,7 +370,7 @@ public abstract class WebGraphics implements Graphics {
     }
 
     @JSBody(script = "return devicePixelRatio || 1;")
-    private static native int getNativeScreenDensityNATIVE();
+    private static native double getNativeScreenDensityNATIVE();
 
     @JSBody(script = "return screen.width;")
     private static native int getScreenWidthNATIVE();


### PR DESCRIPTION
Devices may report values like `1.25`, which will be converted to `1`.

(download and zoom in the images below to see the difference: label and dialog stay crisp after the fix)

Before:

<img width="840" height="271" alt="image" src="https://github.com/user-attachments/assets/71cf0f28-3659-4041-9d3c-807ff6e8915c" />

After:

<img width="685" height="236" alt="image" src="https://github.com/user-attachments/assets/eff26a45-a0f2-4d92-8d97-f1779f8adcd1" />

