### PR TITLE
Remove fields shadowing AbstractInput's key state

### DIFF
--- a/backends/backend-web/src/main/java/com/github/xpenatan/gdx/teavm/backends/web/WebInput.java
+++ b/backends/backend-web/src/main/java/com/github/xpenatan/gdx/teavm/backends/web/WebInput.java
@@ -60,8 +60,6 @@ public class WebInput extends AbstractInput implements EventListener<Event> {
     private int[] deltaX = new int[MAX_TOUCHES];
     private int[] deltaY = new int[MAX_TOUCHES];
     IntSet pressedButtons = new IntSet();
-    int pressedKeyCount = 0;
-    boolean keyJustPressed = false;
     boolean[] justPressedButtons = new boolean[5];
     InputProcessor processor;
     long currentEventTimeStamp;


### PR DESCRIPTION
WebInput re-declared pressedKeyCount and keyJustPressed, shadowing the protected fields inherited from AbstractInput. All key handling wrote to the subclass copies while AbstractInput.isKeyPressed(Keys.ANY_KEY) and isKeyJustPressed(Keys.ANY_KEY) read the parent copies, which stayed 0/false - so both ANY_KEY queries never returned true on this backend.

Deleting the shadowing declarations makes the existing handlers write to the inherited fields, fixing the ANY_KEY queries with no behavior change otherwise.