### PR TITLE
Remove field shadowing FileHandle's type

### DIFF
--- a/backends/backend-web/src/main/java/com/github/xpenatan/gdx/teavm/backends/web/WebFileHandle.java
+++ b/backends/backend-web/src/main/java/com/github/xpenatan/gdx/teavm/backends/web/WebFileHandle.java
@@ -24,7 +24,6 @@ import java.io.Writer;
  */
 public class WebFileHandle extends FileHandle {
     private final String file;
-    private final FileType type;
 
     private WebFiles teaFiles;
 


### PR DESCRIPTION
WebFileHandle declared its own private FileType type, shadowing the protected field of the same name in FileHandle. Nothing ever assigned the inherited field, so it stayed null for every handle, and the inherited methods that read it directly broke:

- hashCode() throws NullPointerException on type.hashCode(), so a file handle cannot be used as a key in any HashMap/ObjectMap. On the wasm-gc target this is an uncatchable "dereferencing a null pointer" RuntimeError that takes down the whole application.
- equals() compares type == other.type, which was always null == null, so handles of different file types compared equal when their paths matched.

The field is a plain enum that the backend already receives in the constructor, so unlike the java.io.File field there is no reason to shadow it: dropping the declaration makes the existing assignment target the inherited field and both methods behave correctly.