### PR TITLE
Guard against gdx2d returning a null pixmap

### DIFF
--- a/backends/backend-web/emu/emu/com/badlogic/gdx/graphics/g2d/Gdx2DPixmapNative.java
+++ b/backends/backend-web/emu/emu/com/badlogic/gdx/graphics/g2d/Gdx2DPixmapNative.java
@@ -23,8 +23,14 @@ public class Gdx2DPixmapNative implements Disposable {
     private Int32Array nativeData;
     private ByteBuffer buffer;
 
-    public Gdx2DPixmapNative(byte[] encodedData, int offset, int len, int requestedFormat) {
+    /**
+     * @throws GdxRuntimeException if the image data could not be loaded.
+     */
+    public Gdx2DPixmapNative(byte[] encodedData, int offset, int len, int requestedFormat) throws GdxRuntimeException {
         nativeData = loadNative(encodedData, offset, len);
+        if(nativeData == null) {
+            throw new GdxRuntimeException("Couldn't load pixmap from image data");
+        }
         updateNativeData();
 
         if(requestedFormat != 0 && requestedFormat != format) {
@@ -37,6 +43,9 @@ public class Gdx2DPixmapNative implements Disposable {
      */
     public Gdx2DPixmapNative(int width, int height, int format) throws GdxRuntimeException {
         nativeData = newPixmapNative(width, height, format);
+        if(nativeData == null) {
+            throw new GdxRuntimeException("Couldn't allocate pixmap");
+        }
         updateNativeData();
     }
 
@@ -200,6 +209,9 @@ public class Gdx2DPixmapNative implements Disposable {
             "Gdx.writeArrayToMemory(buffer, cBuffer);" +
             "var pixmap = Gdx.Gdx.prototype.g2d_load(cBuffer, offset, len);" +
             "Gdx._free(cBuffer);" +
+            "if(pixmap === null || Gdx.getPointer(pixmap) === 0) {" +
+            "   return null;" +
+            "}" +
             "var pixels = Gdx.Gdx.prototype.g2d_get_pixels(pixmap);" +
             "var pixmapAddr = Gdx.getPointer(pixmap);" +
             "var format = pixmap.get_format();" +
@@ -239,6 +251,9 @@ public class Gdx2DPixmapNative implements Disposable {
 
     @JSBody(params = {"width", "height", "format"}, script = "" +
             "var pixmap = Gdx.Gdx.prototype.g2d_new(width, height, format);" +
+            "if(pixmap === null || Gdx.getPointer(pixmap) === 0) {" +
+            "   return null;" +
+            "}" +
             "var pixels = Gdx.Gdx.prototype.g2d_get_pixels(pixmap);" +
             "var pixmapAddr = Gdx.getPointer(pixmap);" +
             "var format = pixmap.get_format();" +


### PR DESCRIPTION
g2d_load returns a null pointer when it cannot decode the image data, and g2d_new does the same when allocation fails. Both JSBody scripts passed that result straight into g2d_get_pixels and pixmap.get_format(), and the constructors then read the resulting nativeData, so a single corrupt or oversized image took down the whole application instead of raising an error the caller could handle. On the wasm-gc target it surfaces as an uncatchable "dereferencing a null pointer" RuntimeError, so not even a try/catch around the Pixmap constructor helps.

The reference JNI implementation kept next to each script already guards this with "if(pixmap==0) return 0;". This restores the same guard for the web backend and turns the failure into the GdxRuntimeException the second constructor already documents.

Note the check is on Gdx.getPointer(pixmap) rather than the returned value: embind hands back a wrapper object around the null pointer, so comparing the wrapper itself against null is not enough.