### PR TITLE
Pause audio when the page is hidden

### DIFF
--- a/backends/backend-web/src/main/java/com/github/xpenatan/gdx/teavm/backends/web/webaudio/howler/HowlTeaAudio.java
+++ b/backends/backend-web/src/main/java/com/github/xpenatan/gdx/teavm/backends/web/webaudio/howler/HowlTeaAudio.java
@@ -1,5 +1,6 @@
 package com.github.xpenatan.gdx.teavm.backends.web.webaudio.howler;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.audio.AudioDevice;
 import com.badlogic.gdx.audio.AudioRecorder;
 import com.badlogic.gdx.audio.Music;
@@ -9,10 +10,11 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.github.xpenatan.gdx.teavm.backends.web.WebAudio;
 
 public class HowlTeaAudio implements WebAudio {
-    private HowlerAudioManager webAudioAPIManager = null;
+    private final HowlerAudioManager webAudioAPIManager;
 
     public HowlTeaAudio() {
         webAudioAPIManager = new HowlerAudioManager();
+        Gdx.app.addLifecycleListener(webAudioAPIManager);
     }
 
     @Override
@@ -47,5 +49,6 @@ public class HowlTeaAudio implements WebAudio {
 
     @Override
     public void dispose() {
+        Gdx.app.removeLifecycleListener(webAudioAPIManager);
     }
 }

--- a/backends/backend-web/src/main/java/com/github/xpenatan/gdx/teavm/backends/web/webaudio/howler/HowlerAudioManager.java
+++ b/backends/backend-web/src/main/java/com/github/xpenatan/gdx/teavm/backends/web/webaudio/howler/HowlerAudioManager.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.LifecycleListener;
 import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.files.FileHandle;
+import org.teavm.jso.JSBody;
 
 public class HowlerAudioManager implements LifecycleListener {
 
@@ -16,16 +17,35 @@ public class HowlerAudioManager implements LifecycleListener {
     }
     @Override
     public void pause() {
-
+        if(hasHowlerContext()) {
+            suspendAudioContext();
+        }
     }
 
     @Override
     public void resume() {
-
+        if(hasHowlerContext()) {
+            resumeAudioContext();
+        }
     }
 
     @Override
     public void dispose() {
 
     }
+
+    /** Suspends the shared AudioContext. */
+    @JSBody(script = "Howler.ctx.suspend();")
+    private static native void suspendAudioContext();
+
+    /** Resumes the shared AudioContext. */
+    @JSBody(script = "Howler.ctx.resume();")
+    private static native void resumeAudioContext();
+
+    /**
+     * The {@code typeof Howler} guard exists because howler.js is script-loaded asynchronously
+     * while lifecycle events can already fire during startup.
+     */
+    @JSBody(script = "return typeof Howler !== 'undefined' && Howler.usingWebAudio && !!Howler.ctx;")
+    private static native boolean hasHowlerContext();
 }


### PR DESCRIPTION
The web backend already dispatches pause/resume to registered LifecycleListeners on visibilitychange, and HowlerAudioManager implements LifecycleListener - but its pause() and resume() bodies were empty and the manager was never registered, so a hidden page kept playing (and decoding) audio over a frozen requestAnimationFrame loop. Every other libGDX backend silences audio in this situation.

Suspend the shared AudioContext on pause and resume it on resume, and register the manager from HowlTeaAudio. Suspending (rather than muting or stopping) freezes playback in place, resumes from the same position and stops background decoding.